### PR TITLE
QL2 header files + ctypesgen

### DIFF
--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/ql2types.py
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/ql2types.py
@@ -1,0 +1,575 @@
+
+QLDeviceId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 316
+
+QLDeviceGroupId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 327
+
+QLDeviceOrGroupId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 341
+
+QLSettingsId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 353
+
+QLCalibrationId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 365
+
+QLTargetId = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 377
+
+enum_anon_1 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_OK = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_CALIBRATING = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_LEFT_DATA = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_RIGHT_DATA = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_DATA = 4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QLCalibrationStatus = enum_anon_1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+enum_anon_2 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_5 = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_9 = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_16 = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QLCalibrationType = enum_anon_2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+enum_anon_3 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QL_DEVICE_BANDWIDTH_MODE_AUTO = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QL_DEVICE_BANDWIDTH_MODE_MANUAL = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QLDeviceBandwidthMode = enum_anon_3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+enum_anon_4 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_RIGHT = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT_OR_RIGHT = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT_AND_RIGHT = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QLDeviceEyesToUse = enum_anon_4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+enum_anon_5 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QL_DEVICE_GAIN_MODE_AUTO = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QL_DEVICE_GAIN_MODE_MANUAL = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QLDeviceGainMode = enum_anon_5 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+enum_anon_6 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_NONE = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_FRAMES = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_TIME = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_FRAMES = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_TIME = 4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_WEIGHTED_PREVIOUS_FRAME = 5 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QLDeviceGazePointFilterMode = enum_anon_6 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+enum_anon_7 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QL_DEVICE_IR_LIGHT_MODE_OFF = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QL_DEVICE_IR_LIGHT_MODE_AUTO = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QLDeviceIRLightMode = enum_anon_7 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+enum_anon_8 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_UNAVAILABLE = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_STOPPED = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_INITIALIZED = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_STARTED = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QLDeviceStatus = enum_anon_8 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+enum_anon_9 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_OK = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DEVICE_ID = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_SETTINGS_ID = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_CALIBRATION_ID = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_TARGET_ID = 4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_PASSWORD = 5 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_PATH = 6 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DURATION = 7 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_POINTER = 8 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_TIMEOUT_ELAPSED = 9 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INTERNAL_ERROR = 10 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_BUFFER_TOO_SMALL = 11 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_CALIBRAION_NOT_INITIALIZED = 12 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_DEVICE_NOT_STARTED = 13 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_NOT_SUPPORTED = 14 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_NOT_FOUND = 15 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_UNAUTHORIZED_APPLICATION_RUNNING = 16 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DEVICE_GROUP_ID = 17 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QLError = enum_anon_9 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+enum_anon_10 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QL_EYE_TYPE_LEFT = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QL_EYE_TYPE_RIGHT = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QLEyeType = enum_anon_10 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+enum_anon_11 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_OFF = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_ON = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_LEFT_EYE_STATUS = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_RIGHT_EYE_STATUS = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_LEFT_EYE_STATUS_FILTERED = 4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_RIGHT_EYE_STATUS_FILTERED = 5 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QLIndicatorMode = enum_anon_11 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+enum_anon_12 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QL_INDICATOR_TYPE_LEFT = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QL_INDICATOR_TYPE_RIGHT = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QLIndicatorType = enum_anon_12 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+enum_anon_13 = c_int # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT = 0 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT8 = 1 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT16 = 2 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT32 = 3 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT64 = 4 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT = 5 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT8 = 6 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT16 = 7 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT32 = 8 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT64 = 9 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_FLOAT = 10 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_DOUBLE = 11 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_BOOL = 12 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_STRING = 13 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_VOID_POINTER = 14 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QLSettingType = enum_anon_13 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 788
+class struct_anon_14(Structure):
+    pass
+
+struct_anon_14.__slots__ = [
+    'targetId',
+    'x',
+    'y',
+]
+struct_anon_14._fields_ = [
+    ('targetId', QLTargetId),
+    ('x', c_float),
+    ('y', c_float),
+]
+
+QLCalibrationTarget = struct_anon_14 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 788
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 812
+class struct_anon_15(Structure):
+    pass
+
+struct_anon_15.__slots__ = [
+    'x',
+    'y',
+    'score',
+]
+struct_anon_15._fields_ = [
+    ('x', c_float),
+    ('y', c_float),
+    ('score', c_float),
+]
+
+QLCalibrationScore = struct_anon_15 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 812
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 834
+class struct_anon_16(Structure):
+    pass
+
+struct_anon_16.__slots__ = [
+    'sensorWidth',
+    'sensorHeight',
+    'serialNumber',
+    'modelName',
+]
+struct_anon_16._fields_ = [
+    ('sensorWidth', c_int),
+    ('sensorHeight', c_int),
+    ('serialNumber', c_char * 128),
+    ('modelName', c_char * 128),
+]
+
+QLDeviceInfo = struct_anon_16 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 834
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 845
+class struct_anon_17(Structure):
+    pass
+
+struct_anon_17.__slots__ = [
+    'x',
+    'y',
+]
+struct_anon_17._fields_ = [
+    ('x', c_double),
+    ('y', c_double),
+]
+
+QLXYPairDouble = struct_anon_17 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 845
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 856
+class struct_anon_18(Structure):
+    pass
+
+struct_anon_18.__slots__ = [
+    'x',
+    'y',
+]
+struct_anon_18._fields_ = [
+    ('x', c_float),
+    ('y', c_float),
+]
+
+QLXYPairFloat = struct_anon_18 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 856
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 876
+class struct_anon_19(Structure):
+    pass
+
+struct_anon_19.__slots__ = [
+    'x',
+    'y',
+    'width',
+    'height',
+]
+struct_anon_19._fields_ = [
+    ('x', c_int),
+    ('y', c_int),
+    ('width', c_int),
+    ('height', c_int),
+]
+
+QLRectInt = struct_anon_19 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 876
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 920
+class struct_anon_20(Structure):
+    pass
+
+struct_anon_20.__slots__ = [
+    'PixelData',
+    'Width',
+    'Height',
+    'Timestamp',
+    'Gain',
+    'FrameNumber',
+    'ROI',
+    'Reserved',
+]
+struct_anon_20._fields_ = [
+    ('PixelData', POINTER(c_ubyte)),
+    ('Width', c_int),
+    ('Height', c_int),
+    ('Timestamp', c_double),
+    ('Gain', c_int),
+    ('FrameNumber', c_long),
+    ('ROI', QLRectInt),
+    ('Reserved', POINTER(None) * 12),
+]
+
+QLImageData = struct_anon_20 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 920
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 959
+class struct_anon_21(Structure):
+    pass
+
+struct_anon_21.__slots__ = [
+    'Found',
+    'Calibrated',
+    'PupilDiameter',
+    'Pupil',
+    'Glint0',
+    'Glint1',
+    'GazePoint',
+    'Reserved',
+]
+struct_anon_21._fields_ = [
+    ('Found', c_bool),
+    ('Calibrated', c_bool),
+    ('PupilDiameter', c_float),
+    ('Pupil', QLXYPairFloat),
+    ('Glint0', QLXYPairFloat),
+    ('Glint1', QLXYPairFloat),
+    ('GazePoint', QLXYPairFloat),
+    ('Reserved', POINTER(None) * 16),
+]
+
+QLEyeData = struct_anon_21 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 959
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 988
+class struct_anon_22(Structure):
+    pass
+
+struct_anon_22.__slots__ = [
+    'Valid',
+    'x',
+    'y',
+    'LeftWeight',
+    'RightWeight',
+    'Reserved',
+]
+struct_anon_22._fields_ = [
+    ('Valid', c_bool),
+    ('x', c_float),
+    ('y', c_float),
+    ('LeftWeight', c_float),
+    ('RightWeight', c_float),
+    ('Reserved', POINTER(None) * 16),
+]
+
+QLWeightedGazePoint = struct_anon_22 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 988
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 1033
+class struct_anon_23(Structure):
+    pass
+
+struct_anon_23.__slots__ = [
+    'ImageData',
+    'LeftEye',
+    'RightEye',
+    'WeightedGazePoint',
+    'Focus',
+    'Distance',
+    'Bandwidth',
+    'DeviceId',
+    'Reserved',
+]
+struct_anon_23._fields_ = [
+    ('ImageData', QLImageData),
+    ('LeftEye', QLEyeData),
+    ('RightEye', QLEyeData),
+    ('WeightedGazePoint', QLWeightedGazePoint),
+    ('Focus', c_float),
+    ('Distance', c_float),
+    ('Bandwidth', c_int),
+    ('DeviceId', QLDeviceId),
+    ('Reserved', POINTER(None) * 14),
+]
+
+QLFrameData = struct_anon_23 # C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 1033
+
+__const = c_int # <command-line>: 5
+
+# <command-line>: 8
+try:
+    CTYPESGEN = 1
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 19
+try:
+    STRING_LENGTH_128 = 128
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 58
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_MODE = 'DeviceBandwidthMode'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 69
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL = 'DeviceBandwidthPercentFull'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 80
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING = 'DeviceBandwidthPercentTracking'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 92
+try:
+    QL_SETTING_DEVICE_BINNING = 'DeviceBinning'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 102
+try:
+    QL_SETTING_DEVICE_CALIBRATE_ENABLED = 'DeviceCalibrateEnabled'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 109
+try:
+    QL_SETTING_DEVICE_DISTANCE = 'DeviceDistance'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 116
+try:
+    QL_SETTING_DEVICE_EXPOSURE = 'DeviceExposure'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 127
+try:
+    QL_SETTING_DEVICE_FLIP_X = 'DeviceFlipX'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 138
+try:
+    QL_SETTING_DEVICE_FLIP_Y = 'DeviceFlipY'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 148
+try:
+    QL_SETTING_DEVICE_GAIN_MODE = 'DeviceGainMode'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 159
+try:
+    QL_SETTING_DEVICE_GAIN_VALUE = 'DeviceGainValue'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 169
+try:
+    QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE = 'DeviceGazePointFilterMode'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 179
+try:
+    QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE = 'DeviceGazePointFilterValue'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 189
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_ENABLED = 'DeviceImageProcessingEnabled'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 198
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND = 'DeviceImageProcessingEyesToUse'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 211
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT = 'DeviceImageProcessingEyeRadiusLeft'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 224
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT = 'DeviceImageProcessingEyeRadiusRight'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 234
+try:
+    QL_SETTING_DEVICE_INTERPOLATE_ENABLED = 'DeviceInterpolateEnabled'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 242
+try:
+    QL_SETTING_DEVICE_IR_LIGHT_MODE = 'DeviceIRLightMode'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 249
+try:
+    QL_SETTING_DEVICE_LENS_FOCAL_LENGTH = 'DeviceLensFocalLength'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 260
+try:
+    QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_X = 'DeviceRoiMoveThresholdPercentX'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 271
+try:
+    QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_Y = 'DeviceRoiMoveThresholdPercentY'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 281
+try:
+    QL_SETTING_DEVICE_ROI_SIZE_PERCENT_X = 'DeviceRoiSizePercentX'
+except:
+    pass
+
+# C:\\Users\\Peter Hyatt\\Documents\\GitHub\\ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 291
+try:
+    QL_SETTING_DEVICE_ROI_SIZE_PERCENT_Y = 'DeviceRoiSizePercentY'
+except:
+    pass
+
+# No inserted files
+

--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/quicklink2.py
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/quicklink2.py
@@ -5,9 +5,38 @@ Quicklink.py
 Copyright (C) 2012 EyeTech Inc.
 Distributed under the terms of the GNU General Public License (GPL version 3 or any later version).
 
-.. fileauthor:: Eye Tech Inc. & Sol Simpson
+.. fileauthor:: Eye Tech Inc. & Sol Simpson & Peter Hyatt
 """
 from ctypes import *
+from ql2types import  * 
+
+import inspect
+
+STRING_LENGTH_128 = 128
+QL_SETTING_DEVICE_BANDWIDTH_MODE = "DeviceBandwidthMode"
+QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL = "DeviceBandwidthPercentFull"
+QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING = "DeviceBandwidthPercentTracking"
+QL_SETTING_DEVICE_BINNING = "DeviceBinning"
+QL_SETTING_DEVICE_CALIBRATE_ENABLED = "DeviceCalibrateEnabled"
+QL_SETTING_DEVICE_DISTANCE = "DeviceDistance"
+QL_SETTING_DEVICE_EXPOSURE = "DeviceExposure"
+QL_SETTING_DEVICE_FLIP_X = "DeviceFlipX"
+QL_SETTING_DEVICE_FLIP_Y = "DeviceFlipY"
+QL_SETTING_DEVICE_GAIN_MODE = "DeviceGainMode"
+QL_SETTING_DEVICE_GAIN_VALUE = "DeviceGainValue"
+QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE = "DeviceGazePointFilterMode"
+QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE = "DeviceGazePointFilterValue"
+QL_SETTING_DEVICE_IMAGE_PROCESSING_ENABLED = "DeviceImageProcessingEnabled"
+QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND = "DeviceImageProcessingEyesToUse"
+QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT = "DeviceImageProcessingEyeRadiusLeft"
+QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT = "DeviceImageProcessingEyeRadiusRight"
+QL_SETTING_DEVICE_INTERPOLATE_ENABLED = "DeviceInterpolateEnabled"
+QL_SETTING_DEVICE_IR_LIGHT_MODE = "DeviceIRLightMode"
+QL_SETTING_DEVICE_LENS_FOCAL_LENGTH = "DeviceLensFocalLength"
+QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_X = "DeviceRoiMoveThresholdPercentX"
+QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_Y = "DeviceRoiMoveThresholdPercentY"
+QL_SETTING_DEVICE_ROI_SIZE_PERCENT_X = "DeviceRoiSizePercentX"
+QL_SETTING_DEVICE_ROI_SIZE_PERCENT_Y = "DeviceRoiSizePercentY"
 
 # QLRectInt
 #
@@ -72,3 +101,22 @@ def createFrameTest():
     qlImageData.PixelData=(c_ubyte * num_pix)(*pixel_data)
 
     return qlImageData
+
+if __name__ == "__main__":
+    # If this file is ran expicitly, do a test of the functions here.
+    testFrame = createFrameTest()
+
+    if(false):
+        # Print out the entire contents of the Pixel data
+        # ioHub.print2err(testFrame.PixelData[0:testFrame.Width*testFrame.Height])
+        print testFrame.PixelData[0:testFrame.Width*testFrame.Height]
+
+    # Print out 50 lines at a time from the frame
+    for i in range(testFrame.Width * testFrame.Height):
+        print testFrame.PixelData[i],
+        if(i%50 == 0 and i != 0):
+            print " "
+            print i/50, ":",
+    print " "
+    print "done"
+        

--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QLTypes.h
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QLTypes.h
@@ -1,0 +1,1039 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file   QLTypes.h
+///
+/// @brief This file contains the definitions of all the types, structures,
+/// and enumerations available through QuickLink2.dll.
+/// 
+/// @copyright 1996 - 2012, EyeTech Digital Systems
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#ifndef QUICK_LINK_2_TYPES_H
+#define	QUICK_LINK_2_TYPES_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define QUICK_LINK_2_CALL_CONVEN __stdcall
+
+#define STRING_LENGTH_128 128
+
+#if (defined _WIN64) || (defined _M_X64)
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def    QUICK_LINK_64_BIT
+///
+/// @brief This is defined when _WIN64 is defined. _WIN64 is defined by the Microsoft compiler when
+/// targeting a 64 bit platform. Due to errors in some versions of Visual Studio, automatic
+/// syntax highlighting shows _WIN64 as not defined even though it actually is defined at compile
+/// time. To facilitate coding, a check for _M_X64 was added as well which fixes automatic syntax
+/// highlighting. _M_X64 is defined when targeting an AMD64 processor.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QUICK_LINK_64_BIT
+
+#elif defined _WIN32
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def    QUICK_LINK_32_BIT
+///
+/// @brief This is defined when _WIN64 is not defined and when _WIN32 is defined. 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QUICK_LINK_32_BIT
+
+#else
+#error QUICK_LINK_64_BIT or QUICK_LINK_32_BIT must be defined. Please check compiler settings.
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @ingroup Settings
+/// @{
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_BANDWIDTH_MODE
+///
+/// @brief The bandwidth mode the device will use.
+/// 
+/// @see QLDeviceBandwidthMode.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_BANDWIDTH_MODE "DeviceBandwidthMode"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL
+///
+/// @brief The percentage of the bus bandwidth used by the device when searching for eyes. This
+/// value is only used when the QL_SETTING_DEVICE_BANDWIDTH_MODE setting is set to
+/// QL_DEVICE_BANDWIDTH_MODE_MANUAL. 
+/// 
+/// Possible values range from 1-100.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL "DeviceBandwidthPercentFull"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING
+///
+/// @brief The percentage of the bus bandwidth used by the device when at least one eye has been
+/// found and is being tracked. This value is only used when the QL_SETTING_DEVICE_BANDWIDTH_MODE
+/// setting is set to QL_DEVICE_BANDWIDTH_MODE_MANUAL. 
+/// 
+/// Possible values range from 1-100.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING "DeviceBandwidthPercentTracking"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_BINNING
+///
+/// @brief  The number of pixels to combine in the x and y direction.
+/// 
+/// The output pixel values are the average of the combined pixels. Possible values are 1, 2,
+/// and 4. A value of 1 outputs one pixel of data for each pixel on the image sensor. A value of
+/// 2 outputs one pixel of data for every 4 (2 X 2) pixels on the image sensor. A value of 4
+/// outputs one pixel of data for every 16 (4 X 4) pixels on the image sensor.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_BINNING "DeviceBinning"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_CALIBRATE_ENABLED
+///
+/// @brief The flag for enabling/disabling calibration.
+/// 
+/// Possible values are true and false. If false then calibration data collection will be
+/// disabled and new calibrations can not be performed.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_CALIBRATE_ENABLED "DeviceCalibrateEnabled"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_DISTANCE
+///
+/// @brief The approximate distance in centimeters from the user to the device.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_DISTANCE "DeviceDistance"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_EXPOSURE
+///
+/// @brief The exposure time in milliseconds for each frame. Possible values range from 1-50 ms.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_EXPOSURE "DeviceExposure"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_FLIP_X
+///
+/// @brief The horizontal direction of the image.
+/// 
+/// Possible values are true and false. A value of false will result in the right eye being
+/// closest to the origin (0, 0) of the image. A value of true will mirror the image and cause
+/// the left eye to be closest to the origin.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_FLIP_X "DeviceFlipX"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_FLIP_Y
+///
+/// @brief The vertical direction of the image.
+/// 
+/// Possible values are true and false. A value of false will result in the top of the head being
+/// closest to the origin (0, 0) of the image. A value of true will cause the bottom of the face
+/// to be closest to the origin of the image.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_FLIP_Y "DeviceFlipY"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_GAIN_MODE
+///
+/// @brief  The gain mode the device will use.
+/// 
+/// @see QLDeviceGainMode. 
+/// @see QL_SETTING_DEVICE_GAIN_VALUE. 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_GAIN_MODE "DeviceGainMode"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_GAIN_VALUE
+///
+/// @brief The gain value the device will use when the setting QL_SETTING_DEVICE_GAIN_MODE is set to
+/// QL_DEVICE_GAIN_MODE_MANUAL.
+/// 
+/// @see DeviceGainMode. 
+/// @see QL_SETTING_DEVICE_GAIN_MODE. 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_GAIN_VALUE "DeviceGainValue"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE
+///
+/// @brief The filter mode for the output gaze point.
+/// 
+/// @see QLDeviceGazePointFilterMode.
+/// @see QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE "DeviceGazePointFilterMode"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE
+///
+/// @brief The value used for the filtering mode.
+/// 
+/// @see QLDeviceGazePointFilterMode.
+/// @see QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE "DeviceGazePointFilterValue"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_IMAGE_PROCESSING_ENABLED
+///
+/// @brief The flag for enabling/disabling image processing.
+/// 
+/// Possible values are true and false. If false then the eyes will not be searched for and the
+/// output eye information will not be valid.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_IMAGE_PROCESSING_ENABLED "DeviceImageProcessingEnabled"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND
+///
+/// @brief The search setting for the image processing.
+///
+/// @see QLDeviceEyesToUse.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND "DeviceImageProcessingEyesToUse"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT;
+///
+/// @brief The radius of the cornea of the left eye in centimeters. This radius can be
+/// calculated by calling the function QLDevice_CalibrateEyeRadius(). This radius will affect the
+/// calculated distance value that is output for each frame.
+/// 
+/// @see QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT.
+/// @see QLFrameData.
+/// @see QLDevice_CalibrateEyeRadius().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT "DeviceImageProcessingEyeRadiusLeft"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT
+///
+/// @brief The radius of the cornea of the right eye in centimeters. This radius can be
+/// calculated by calling the function QLDevice_CalibrateEyeRadius(). This radius will affect the
+/// calculated distance value that is output for each frame.
+///
+/// @see QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT.
+/// @see QLFrameData.
+/// @see QLDevice_CalibrateEyeRadius().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT "DeviceImageProcessingEyeRadiusRight"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_INTERPOLATE_ENABLED
+///
+/// @brief The flag for enabling/disabling final gaze point interpolation.
+/// 
+/// Possible values are true and false. If false then the final gaze point will not be
+/// interpolated and the output gaze point will not be valid.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_INTERPOLATE_ENABLED "DeviceInterpolateEnabled"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_IR_LIGHT_MODE
+///
+/// @brief The mode of operation for the IR lights of the device.
+/// @see QLDeviceIRLightMode.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_IR_LIGHT_MODE "DeviceIRLightMode"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_LENS_FOCAL_LENGTH
+/// 
+/// @brief The focal length in centimeters of the lens.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_LENS_FOCAL_LENGTH "DeviceLensFocalLength"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_X
+///
+/// @brief The horizontal distance in percentage of the image width that either eye can be from
+/// the left or right edge of the region of interest before the region of interest will move and
+/// try to re-center the eyes.
+/// 
+/// Possible values range from 1-50.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_X "DeviceRoiMoveThresholdPercentX"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_Y
+///
+/// @brief The vertical distance in percentage of the image height that either eye can be from
+/// the top or bottom edge of the region of interest before the region of interest will move and
+/// try to re-center the eyes.
+/// 
+/// Possible values range from 1-50.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_Y "DeviceRoiMoveThresholdPercentY"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_ROI_SIZE_PERCENT_X
+///
+/// @brief The width of the region of interest in percentage of the horizontal sensor size when
+/// the eyes are being tracked.
+/// 
+/// Possible values range from 1-100.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_ROI_SIZE_PERCENT_X "DeviceRoiSizePercentX"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @def QL_SETTING_DEVICE_ROI_SIZE_PERCENT_Y
+///
+/// @brief The height of the region of interest in percentage of the vertical sensor size when
+/// the eyes are being tracked.
+/// 
+/// Possible values range from 1-100.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define QL_SETTING_DEVICE_ROI_SIZE_PERCENT_Y "DeviceRoiSizePercentY"
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//------------------------------------------------------------------------------
+// Type Defines
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef int QLDeviceId
+///
+/// @brief A unique identifier that is used to access a device.
+/// 
+/// Once QuickLink2.dll is loaded a QLDeviceId will always refer to the same device until
+/// QuickLink2.dll is unloaded. This is true even if the device is disconnected from the computer
+/// and then later reconnected. A device is not guaranteed to have the same QLDeviceId value from
+/// one loading of QuickLink2.dll to the next.
+///
+/// @ingroup Device
+/// 		 
+/// @see QLDevice_Enumerate().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLDeviceId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef    int QLDeviceGroupId
+///
+/// @brief A unique identifier that is used to access a group of devices. 
+///
+/// @ingroup Device
+/// 		 
+/// @see QLDeviceGroup_Create().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLDeviceGroupId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef    int QLDeviceOrGroupId
+///
+/// @brief This indicates support of either a QLDeviceId or a QLDeviceGroupId. 
+///
+/// @ingroup Device
+/// 		 
+/// @see QLDeviceId.
+/// @see QLDeviceGroupId.
+/// @see QLDevice_Enumerate().
+/// @see QLDeviceGroup_Create().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLDeviceOrGroupId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef    int QLSettingsId
+///
+/// @brief A unique identifier that is used to access a settings container. 
+///
+/// @ingroup Settings
+/// 		 
+/// @see QLSettings_Create().
+/// @see QLSettings_Load().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLSettingsId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef    int QLCalibrationId
+///
+/// @brief A unique identifier that is used to access a calibration container. 
+///
+/// @ingroup Calibration
+/// 		 
+/// @see QLCalibration_Create().
+/// @see QLCalibration_Load().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLCalibrationId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @typedef    int QLTargetId
+///
+/// @brief A unique identifier that is used to access a target for a given calibration container.
+///
+/// @ingroup Calibration
+/// 		 
+/// @see QLCalibrationTarget.
+/// @see QLCalibration_GetTargets().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef int QLTargetId;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLCalibrationStatus
+///
+/// @brief Status values for a calibration target
+/// 		 
+/// @see QLCalibration_GetStatus().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The calibration target has data for both the left and right eyes.
+    QL_CALIBRATION_STATUS_OK =            0,
+
+    /// The calibration target is in the process of calibrating.
+    QL_CALIBRATION_STATUS_CALIBRATING =   1,
+
+    /// The calibration target has data for the right eye but not the left eye.
+    QL_CALIBRATION_STATUS_NO_LEFT_DATA =  2,
+
+    /// The calibration target has data for the left eye but not the right eye.
+    QL_CALIBRATION_STATUS_NO_RIGHT_DATA = 3,
+
+    // The calibration target does not have data for the left or right eye.
+    QL_CALIBRATION_STATUS_NO_DATA =       4
+} QLCalibrationStatus;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLCalibrationType
+///
+/// @brief Values that identify different calibration modes.
+/// 		 
+/// @see QLCalibration_Initialize().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// A five point calibration.
+    QL_CALIBRATION_TYPE_5 =  0,
+
+    /// A nine point calibration.
+    QL_CALIBRATION_TYPE_9 =  1,
+
+    /// A sixteen point calibration.
+    QL_CALIBRATION_TYPE_16 = 2
+} QLCalibrationType;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceBandwidthMode
+///
+/// @brief Values that identify which bandwidth mode to use.
+/// 		 
+/// @see QL_SETTING_DEVICE_BANDWIDTH_MODE.
+/// @see QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL.
+/// @see QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The device will automatically adjust the bandwidth value until the best value is found.
+    QL_DEVICE_BANDWIDTH_MODE_AUTO	=  0,
+
+    /// The device will use a fixed bandwidth value.
+    QL_DEVICE_BANDWIDTH_MODE_MANUAL  =  1
+} QLDeviceBandwidthMode;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceEyesToUse
+///
+/// @brief Values that identify which eyes the device should process.
+/// 		 
+/// @see QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// Only search for and process the left eye
+    QL_DEVICE_EYES_TO_USE_LEFT			= 0,
+
+    /// Only search for and process the right eye
+    QL_DEVICE_EYES_TO_USE_RIGHT			= 1,
+
+    /// Search for and process both eyes. If only one eye is found then use it for calculating the
+    /// weighted gaze point. 
+    QL_DEVICE_EYES_TO_USE_LEFT_OR_RIGHT	= 2,
+
+    /// Search for and process both eyes. Both eyes must be found for calculating the weighted gaze
+    /// point. 
+    QL_DEVICE_EYES_TO_USE_LEFT_AND_RIGHT = 3
+} QLDeviceEyesToUse;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceGainMode
+///
+/// @brief Values that identify which gain mode to use.
+/// 		 
+/// @see QL_SETTING_DEVICE_GAIN_MODE.
+/// @see QL_SETTING_DEVICE_GAIN_VALUE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The device will automatically adjust the vain value.
+    QL_DEVICE_GAIN_MODE_AUTO	=  0,
+
+    /// The device will use a fixed gain value.
+    QL_DEVICE_GAIN_MODE_MANUAL  =  1
+} QLDeviceGainMode;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceGazePointFilterMode
+///
+/// @brief Values that identify which gain mode to use.
+///
+/// @see QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE.
+/// @see QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// No gaze point filtering will be done.
+	QL_DEVICE_GAZE_POINT_FILTER_NONE                    = 0,
+
+    /// The median gaze point value over the last X number of frames, where X equals the value
+    /// represented by the setting
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE. This will produce a gaze point latency time
+    /// of about (X / fps / 2) seconds. 
+	QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_FRAMES           = 1,
+
+    /// The median gaze point value over the last X number of frames, where X is the number of
+    /// frames gathered over twice the amount of milliseconds represented by the setting
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE. This will produce a
+    /// latency of about
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE milliseconds. 
+    QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_TIME             = 2,
+
+    /// The heuristic filter uses different filtering strengths when the eye is moving and when it
+    /// is fixating. When the eye is moving, very little filtering is done which results in very low
+    /// latency. When the eye is fixating, large amounts of filtering are being done which greatly
+    /// reduce the amount of jitter. Durring fixation, filtering is done over the last X number of
+    /// frames where X equals the value represented by the setting
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE. 
+	QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_FRAMES        = 3,
+
+    /// The heuristic filter uses different filtering strengths when the eye is moving and when it
+    /// is fixating. When the eye is moving, very little filtering is done which results in very low
+    /// latency. When the eye is fixating, large amounts of filtering are being done which greatly
+    /// reduce the amount of jitter. Durring fixation, filtering is done over the last X number of
+    /// frames where X equals the number of frames gathered over twice the amount of milliseconds
+    /// represented by the setting
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE. This produces aproximatly
+    /// the same amount of latency durring fixation for all frame rates. 
+	QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_TIME          = 4,
+
+    /// The weighted previous frame mode filters the gaze point by summing the current weighted gaze
+    /// point location and the previous weighted gazepoint location. The weights are based on the
+    /// distance the current gaze point is away from the previous gaze point. The larger the
+    /// distance, the greater the weight on the current gaze point. The smaller the distance, the
+    /// greater the weight on the previous gaze point. This results in very low latency when the eye
+    /// is moving and very low jitter when the eye is fixating. The value represented by the setting
+    /// @ref QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE affects the rate at which
+    /// the weighting changes from the previous gaze point to the current gaze point. Possible
+    /// values range between 0 and 100. 
+    QL_DEVICE_GAZE_POINT_FILTER_WEIGHTED_PREVIOUS_FRAME = 5
+
+} QLDeviceGazePointFilterMode;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceIRLightMode
+///
+/// @brief Values that identify which gain mode to use.
+///
+/// @see QL_SETTING_DEVICE_IR_LIGHT_MODE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The IR lights on the device will be off. Use this when other IR light sources are being
+    /// used. 
+    QL_DEVICE_IR_LIGHT_MODE_OFF  =  0,
+
+    /// The IR lights on the device will be on. This should be used for normal operation.
+    QL_DEVICE_IR_LIGHT_MODE_AUTO	=  1
+} QLDeviceIRLightMode;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLDeviceStatus
+///
+/// @brief Status values for a device.
+///
+/// @see QLDevice_GetStatus().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The device cannot be detected. It has probably been disconnected from the computer.
+    QL_DEVICE_STATUS_UNAVAILABLE = 0,
+
+    /// The device is stopped.
+    QL_DEVICE_STATUS_STOPPED =     1,
+
+    /// The device is in the process of being started.
+    QL_DEVICE_STATUS_INITIALIZED = 2,
+
+    /// The device is running.
+    QL_DEVICE_STATUS_STARTED =   3
+} QLDeviceStatus;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum   QLError
+///
+/// @brief  Error codes returned from Quick Link 2 functions.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The function successfully completed.
+    QL_ERROR_OK =                               0,
+
+    /// The input device ID is invalid.
+    QL_ERROR_INVALID_DEVICE_ID =                1,
+    
+    /// The input settings ID is invalid.
+    QL_ERROR_INVALID_SETTINGS_ID =              2,
+
+    /// The input calibration ID is invalid.
+    QL_ERROR_INVALID_CALIBRATION_ID =           3,
+
+    /// The input target ID is invalid.
+    QL_ERROR_INVALID_TARGET_ID =                4,
+
+    /// The password for the device is not valid.
+    QL_ERROR_INVALID_PASSWORD =                 5,
+
+    /// The input path is invalid.
+    QL_ERROR_INVALID_PATH =                     6,
+
+    /// The input duration is invalid.
+    QL_ERROR_INVALID_DURATION =                 7,
+
+    /// The input pointer is NULL.
+	QL_ERROR_INVALID_POINTER =                  8,
+
+    /// The timeout time was reached.
+    QL_ERROR_TIMEOUT_ELAPSED =                  9,
+
+    /// An internal error occurred. Contact EyeTech for further help.
+    QL_ERROR_INTERNAL_ERROR =                   10,
+
+    /// The input buffer is is not large enough.
+    QL_ERROR_BUFFER_TOO_SMALL =                 11,
+
+    /// The calibration container has not been initialized. See QLCalibration_Initialize()
+    QL_ERROR_CALIBRAION_NOT_INITIALIZED =       12,
+
+    /// The device has not been started. See QLDevice_Start()
+    QL_ERROR_DEVICE_NOT_STARTED =               13,
+
+    /// The setting is not supported by the given device. See QLDevice_IsSettingSupported()
+	QL_ERROR_NOT_SUPPORTED =			        14,
+
+    /// The setting is not in the settings container.
+	QL_ERROR_NOT_FOUND =    			        15,
+
+	/// The API has detected that an unauthorized applicaion is running on the computer. This occurs
+	/// most often when a device is being used in a way that is prohibited by the original sales
+	/// agreement of the device. For further information please contact EyeTech. 
+	QL_ERROR_UNAUTHORIZED_APPLICATION_RUNNING = 16,
+
+    /// The input device group ID is invalid.
+    QL_ERROR_INVALID_DEVICE_GROUP_ID =          17
+} QLError;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLEyeType
+///
+/// @brief Values that identify an eye.
+///
+/// @see QLCalibration_GetScoring().
+/// @see QLCalibration_AddBias().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The left eye.
+    QL_EYE_TYPE_LEFT =  0,
+
+    /// The right eye.
+    QL_EYE_TYPE_RIGHT = 1
+} QLEyeType;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum   QLIndicatorMode
+///
+/// @brief  Values that identify different indicator modes.
+///
+/// @see QLDevice_SetIndicator().
+/// @see QLDevice_GetIndicator().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The indicator will be off constantly.
+    QL_INDICATOR_MODE_OFF =                       0,
+
+    /// The indicator will be on constantly.
+    QL_INDICATOR_MODE_ON =                        1,
+
+    /// The indicator will show the current tracking status of the left eye.
+    QL_INDICATOR_MODE_LEFT_EYE_STATUS =           2,
+
+    /// The indicator will show the current tracking status of the right eye.
+    QL_INDICATOR_MODE_RIGHT_EYE_STATUS =          3,
+
+    /// The indicator will show the filtered current tracking status of the left eye. This will
+    /// prevent the indicator from flickering if the eye was lost for only a couple of frames. 
+    QL_INDICATOR_MODE_LEFT_EYE_STATUS_FILTERED =  4,
+
+    /// The indicator will show the filtered current tracking status of the right eye. This will
+    /// prevent the indicator from flickering if the eye was lost for only a couple of frames. 
+    QL_INDICATOR_MODE_RIGHT_EYE_STATUS_FILTERED = 5
+} QLIndicatorMode;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum QLIndicatorType
+///
+/// @brief Values that identify an indicator light.
+///
+/// @see QLDevice_SetIndicator().
+/// @see QLDevice_GetIndicator().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// The left indicator light.
+    QL_INDICATOR_TYPE_LEFT =  0,
+
+    /// The right indicator light.
+    QL_INDICATOR_TYPE_RIGHT = 1
+} QLIndicatorType;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @enum   QLSettingType
+///
+/// @brief  Values that identify what data type a pointer points to.
+///
+/// @see QLSettings_SetValue().
+/// @see QLSettings_GetValue().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef enum
+{
+    /// A c/c++ int type
+	QL_SETTING_TYPE_INT =          0,
+
+    /// An 8-bit wide integer type
+	QL_SETTING_TYPE_INT8 =         1,
+
+    /// A 16-bit wide integer type
+	QL_SETTING_TYPE_INT16 =        2,
+
+    /// A 32-bit wide integer type
+	QL_SETTING_TYPE_INT32 =        3,
+
+    /// A 64-bit wide integer type
+	QL_SETTING_TYPE_INT64 =        4,
+
+    /// A c/c++ unsigned int type
+	QL_SETTING_TYPE_UINT =         5,
+
+    /// An 8-bit wide unsigned integer type
+	QL_SETTING_TYPE_UINT8 =        6,
+
+    /// An 16-bit wide unsigned integer type
+	QL_SETTING_TYPE_UINT16 =       7,
+
+    /// An 32-bit wide unsigned integer type
+	QL_SETTING_TYPE_UINT32 =       8,
+
+    /// An 64-bit wide unsigned integer type
+	QL_SETTING_TYPE_UINT64 =       9,
+
+    /// A c/c++ float type
+	QL_SETTING_TYPE_FLOAT =        10,
+
+    /// A c/c++ double type
+	QL_SETTING_TYPE_DOUBLE =       11,
+
+    /// A c/c++ long type
+	QL_SETTING_TYPE_BOOL =         12,
+
+    /// A c/c++ char* type
+	QL_SETTING_TYPE_STRING =       13,
+
+    /// A c/c++ void* type
+	QL_SETTING_TYPE_VOID_POINTER = 14
+} QLSettingType;
+
+
+//------------------------------------------------------------------------------
+// Structures
+//------------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLCalibrationTarget
+///
+/// @brief  Data that identifies a calibration target.
+///
+/// @see QLCalibration_GetTargets().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// An identifying value used to reference the target. This is unique for each target in a given
+    /// calibration container. 
+    QLTargetId targetId;
+
+    /// The x position of the target. This is in percentage of the horizontal area to be
+    /// calibrated (0.-100.) 
+    float x;
+    
+    /// The y position of the target. This is in percentage of the vertical area to be calibrated
+    /// (0.- 100.) 
+    float y;
+} QLCalibrationTarget;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLCalibrationScore
+///
+/// @brief  Values that identify the quality of a calibration at a target.
+///
+/// @see QLCalibration_GetScoring().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// The x offset from the target position for the calibrated gaze point. This is in percentage
+    /// of the horizontal area to be calibrated (0.-100.). Negative are to the left. Positive values
+    /// are to the right. 
+    float x;
+
+    /// The y offset from the target position for the calibrated gaze point. This is in percentage
+    /// of the vertical area to be calibrated( (0.-100.). Negative are above. Positive values are
+    /// below. 
+    float y;
+
+    /// The magnitude of the distance from the calibrated gaze point to the actual target position.
+    /// This can be used to identify which target has the worst calibration. 
+    float score;
+} QLCalibrationScore;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLDeviceInfo
+///
+/// @brief  Device specific information
+///
+/// @see QLDevice_GetInfo().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// The actual sensor width in pixels.
+	int sensorWidth;
+	
+    /// The actual sensor height in pixels.
+    int sensorHeight;
+	
+    /// The serial unique serial number of the device.
+    char serialNumber[STRING_LENGTH_128];
+
+    /// The EyeTech model name of the camera.
+	char modelName[STRING_LENGTH_128];
+} QLDeviceInfo;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLXYPairDouble
+///
+/// @brief  An x-y pair of type double.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    double x;
+    double y;
+} QLXYPairDouble;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLXYPairFloat
+///
+/// @brief  An x-y pair of type float.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    float x;
+    float y;
+} QLXYPairFloat;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct QLRectInt
+///
+/// @brief Information describing a rectangle.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// The x coordinate of the upper left corner of the rectangle.
+    int x;
+
+    /// The y coordinate of the upper left corner of the rectangle.
+    int y;
+
+    /// The width of the rectangle.
+    int width;
+
+    /// The height of the rectangle.
+    int height;
+} QLRectInt;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLImageData
+///
+/// @brief  Information/data about an image 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// The pixel data of the image. The data is single channel grey-scale with 8-bits per pixel.
+    unsigned char* PixelData;
+
+    /// The width in pixels of the image. This can be different than the sensorWidth of the device
+    /// if binning is turned on. 
+    int            Width;
+
+    /// The height in pixels of the image. This can be different than the sensorHeight of the device
+    /// if binning is turned on. 
+    int            Height;
+
+    /// The timestamp of the frame. It is the number of milliseconds from when the computer was
+    /// started. 
+    double         Timestamp;
+
+    /// The gain value of the image.
+    int            Gain;
+
+    /// A number to identify a frame. Checking for non consecutive numbers from frame to frame can
+    /// determine if a frame was lost. 
+    long           FrameNumber;
+
+    /// Information describing the location and size of the region of interest. If the device is not
+    /// in region of interest mode then the x and y values will be zero and the width and height
+    /// values will equal the width and height of the entire image. 
+    QLRectInt      ROI;
+
+#if defined QUICK_LINK_64_BIT
+    /// Reserved for future implementation
+    void*          Reserved[14];
+#elif defined QUICK_LINK_32_BIT
+    /// Reserved for future implementation
+    void*          Reserved[12];
+#endif
+
+} QLImageData;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLEyeData
+///
+/// @brief  Eye specific data.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// Indicates whether the eye is found in the image. If this is false then the rest of the data
+    /// for the eye is not valid. 
+	long          Found;
+	
+    /// Indicates whether the eye is calibrated. If this is false then the GazePoint is not valid
+    /// for the eye. 
+    long          Calibrated;
+	
+	/// The diameter of the pupil in millimeters. The resolution of this measurement is .02mm. If
+	/// the eye is found and the pupil diameter is less than zero then the diameter could not be
+	/// determined and it's value should not be used for that frame. 
+    float         PupilDiameter;
+    
+    /// The position in pixels of the image of the center of the pupil.
+    QLXYPairFloat Pupil;
+
+    /// The position in pixels of the image of the center of one of the glints. Compare the x value
+    /// to determine if this is the left of right glint. 
+	QLXYPairFloat Glint0;
+
+    /// The position in pixels of the image of the center of one of the glints. Compare the x value
+    /// to determine if this is the left of right glint. 
+    QLXYPairFloat Glint1;
+
+    // The position of the gaze point in percentage of the calibrated area. This value is not
+    // constrained to the calibrated area. 
+	QLXYPairFloat GazePoint;
+
+    /// Reserved for future implementation.
+	void*         Reserved[16];
+} QLEyeData;
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLWeightedGazePoint
+///
+/// @brief The averaged gaze point. These values intelligently average the left and right eye
+/// based on which eyes were found and previous data depending on filtering settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// Indicates whether the weighted gaze point is available this frame. If this is false then the
+    /// rest of the data is invalid. 
+	long  Valid;
+
+    /// The x position of the gaze point in percentage of the calibrated area.
+    float x;
+
+    /// The y position of the gaze point in percentage of the calibrated area.
+    float y;
+
+    /// The amount the left eye affected the weighted gaze point.
+    float LeftWeight;
+
+    /// The amount the right eye affected the weighted gaze point.
+    float RightWeight;
+
+    /// Reserved for future implementation.
+	void*               Reserved[16];
+} QLWeightedGazePoint;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @struct   QLFrameData
+///
+/// @brief The complete data available in each frame.
+/// 	   
+/// @see QLDevice_GetFrame().
+////////////////////////////////////////////////////////////////////////////////////////////////////
+typedef struct
+{
+    /// The image specific data.
+	QLImageData         ImageData;
+
+    /// Left eye specific data.
+	QLEyeData           LeftEye;
+
+    /// Right eye specific data.
+	QLEyeData           RightEye;
+
+    /// An intelligently averaged single gaze point that is the best representation of the user's
+    /// gaze. 
+    QLWeightedGazePoint WeightedGazePoint;
+
+    /// The focus measurement of the eyes in the image. Higher values are better. Typical good
+    /// values range between 15 and 19. 
+    float               Focus;
+
+    /// The distance from the device to the user in centimeters.
+    float               Distance;
+
+    /// The current bandwidth of the device.
+    int                 Bandwidth;
+
+    // The ID of the device that is the source for the current frame.
+    QLDeviceId          DeviceId;
+
+#if defined QUICK_LINK_64_BIT
+    /// Reserved for future implementation
+    void*          Reserved[15];
+#elif defined QUICK_LINK_32_BIT
+    /// Reserved for future implementation
+    void*          Reserved[14];
+#endif
+
+} QLFrameData;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QuickLink2.h
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QuickLink2.h
@@ -1,0 +1,1752 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file   QuickLink2.h
+///
+/// @brief  This file declares the functions available through QuickLink2.dll.
+/// 
+/// @copyright 1996 - 2012, EyeTech Digital Systems
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#ifndef QUICK_LINK_2_H
+#define	QUICK_LINK_2_H
+
+#include "QLTypes.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLAPI_GetVersion( int bufferSize, char* buffer);
+///
+/// @ingroup API
+/// @brief Get the version of the API.
+/// 
+/// This function retrieves the version string of the API.
+///
+/// @param [in] bufferSize The size of the output buffer in bytes.
+/// @param [out] buffer    A pointer to a char buffer that receives the version string.
+///
+/// @return The success of the function.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLAPI_GetVersion(
+        int bufferSize, 
+        char* buffer);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLAPI_ExportSettings( QLSettingsId settings);
+///
+/// @ingroup API
+/// @brief Export the system level API settings that are currently being used by the API.
+/// 
+/// This function exports the current system level API settings values to the specified settings
+/// container. It will only export the values for setting that have been added to the settings
+/// container. To add a setting to the settings container use the function
+/// QLSettings_AddSetting() or the function QLSettings_SetValue().
+///
+/// @param [in] settings The ID of the settings container that will receive the exported values
+///                      from the API. This ID is obtained by calling either the function
+///                      QLSettings_Create() or the function QLSettings_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// values were successfully exported.
+/// 
+/// @see Settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLAPI_ExportSettings(
+        QLSettingsId settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLAPI_ImportSettings( QLSettingsId settings);
+///
+/// @ingroup API
+/// @brief Import settings values to the system level of the API.
+/// 
+/// This function imports settings values to the system level of the API from the specified
+/// settings container. The new settings values will take effect immediately.
+/// 
+/// Not all settings are supported at the system level of the API. Only settings values that are
+/// supported will be imported from the settings container. All other settings in the container
+/// will be ignored.
+///
+/// @param [in] settings The ID of the settings container that will supply the settings values
+///                      that will be imported to the API. This ID is obtained by calling either
+///                      the function QLSettings_Create() or the function QLSettings_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// values were successfully imported to API.
+/// 
+/// @see Settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLAPI_ImportSettings(
+        QLSettingsId settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_Enumerate( int* numDevices,
+/// QLDeviceId* deviceBuffer);
+///
+/// @ingroup Device
+/// @brief Enumerate the bus to find connected EyeTech devices.
+/// 
+/// This function creates an ID for each EyeTech device connected to the system. The IDs are used
+/// in other functions to reference a specific device.
+///
+/// @param [in,out] numDevices A pointer to an integer containing the size of deviceBuffer. When
+///                            the function returns the integer contains the number of devices
+///                            found on the bus.
+/// @param [out] deviceBuffer  A pointer to a QLDeviceId buffer that will receive the IDs of the
+///                            devices that are connected to the system.
+///
+/// @return The success of the function. If the return value is QL_ERROR_BUFFER_TOO_SMALL then
+/// the device buffer was too small to contain all the devices that are attached to the computer.
+/// numDevices will contain the number of devices detected and the deviceBuffer should be resized
+/// to be at least as large this large before this function is called again. If the return value
+/// is QL_ERROR_OK then the bus was successfully enumerated and the device buffer contains IDs
+/// for all the EyeTech devices that were detected.
+/// 
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_Enumerate(
+        int* numDevices, 
+        QLDeviceId* deviceBuffer);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_GetInfo( QLDeviceId device, QLDeviceInfo* info);
+///
+/// @ingroup Device
+/// @brief Get device specific information for a device.
+///
+/// @param [in] device The ID of the device from which to get information. This ID is obtained
+///                    by calling the function QLDevice_Enumerate().
+/// @param [out] info  A pointer to a QLDeviceInfo object. This object will receive the
+///                    information about the device.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the info
+/// parameter contains the information about the device.
+///
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_GetInfo(
+        QLDeviceId device, 
+        QLDeviceInfo* info);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_GetStatus( QLDeviceId device,
+/// QLDeviceStatus* status);
+///
+/// @ingroup Device
+/// @brief Get the status of a device.
+/// 
+/// This function causes momentary slowness of the device while trying to determine the status.
+/// It can greatly affect frame rates and should not be called when capture times are critical.
+///
+/// @param [in] device  The ID of the device from which to get the status. This ID is obtained by
+///                     calling the function QLDevice_Enumerate().
+/// @param [out] status A pointer to a QLDeviceStatus object. This object will receive the status
+///                     of the device.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the status
+/// parameter contains the status of the device.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_GetStatus(
+        QLDeviceId device, 
+        QLDeviceStatus* status);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_ExportSettings( QLDeviceId device,
+/// QLSettingsId settings);
+///
+/// @ingroup Device
+/// @brief Export the active settings values that are being used by a device.
+/// 
+/// This function exports the settings values that are currently being used by the specified
+/// device. The values are exported to the specified settings container. It will only export the
+/// values for setting that have been added to the settings container. To add a setting to the
+/// settings container use the function QLSettings_AddSetting() or the function
+/// QLSettings_SetValue().
+/// 
+/// Not all settings are supported by all devices. To determine if a setting is supported by a
+/// particular device then use the function QLDevice_IsSettingSupported().
+///
+/// @param [in] device   The ID of the device from which to export the settings. This ID is
+///                      obtained by calling the function QLDevice_Enumerate().
+/// @param [in] settings The ID of the settings container that will receive the exported values
+///                      from the device. This ID is obtained by calling either the function
+///                      QLSettings_Create() or the function QLSettings_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// values were successfully exported from the device.
+/// 
+/// @see Settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_ExportSettings(
+        QLDeviceId device, 
+        QLSettingsId settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_ImportSettings( QLDeviceOrGroupId deviceOrGroup,
+/// QLSettingsId settings);
+///
+/// @ingroup Device
+/// @brief Import settings values for a device and make them active.
+/// 
+/// This function imports settings values for the specified device from the specified settings
+/// container. This operation is synchronous with the device. The new settings values will take
+/// effect after the device has finished processing its current frame, resulting in a latency of
+/// one frame.
+/// 
+/// Not all settings are supported by all devices. Only settings values that are supported by the
+/// specified device will be imported from the settings container. All other settings in the
+/// settings container will be ignored. To determine if a setting is supported by a particular
+/// device then use the function QLDevice_IsSettingSupported().
+/// 
+/// Calling this function using a device group will cause the settings to be imported to all
+/// devices in the group.
+///
+/// @param [in] deviceOrGroup The ID of the device or device group in which to import the settings.
+///                           This ID is obtained by calling either the function
+///                           QLDevice_Enumerate() or the function QLDeviceGroup_Create().
+/// @param [in] settings      The ID of the settings container that will supply the settings values
+///                           that will be imported to the device or group. This ID is obtained
+///                           by calling either the function QLSettings_Create() or the
+///                           function QLSettings_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// values were successfully imported to the device.
+/// 
+/// @see Settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_ImportSettings(
+        QLDeviceOrGroupId deviceOrGroup, 
+        QLSettingsId settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_IsSettingSupported( QLDeviceId device,
+/// const char* settingName);
+///
+/// @ingroup Device
+/// @brief Determine if a setting is supported by a device.
+/// 
+/// This function determines if a setting is supported by a given device. Not all settings are
+/// supported by all devices.
+///
+/// @param [in] device      The ID of the device to check for setting support. This ID is
+///                         obtained by calling the function QLDevice_Enumerate().
+/// @param [in] settingName A pointer to a NULL-terminated string containing the name of the
+///                         setting to check for in the device.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the setting is
+/// supported by the specified device.
+/// 
+/// @see Settings.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_IsSettingSupported(
+        QLDeviceId device, 
+        const char* settingName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_SetPassword( QLDeviceId device,
+/// const char* password);
+///
+/// @ingroup Device
+/// @brief Set the password for a device.
+/// 
+/// This function sets the password for the specified device. The password is usually found on a
+/// label affixed to the device. If the password is not known for a device then contact EyeTech
+/// Digital Systems to obtain it. The password must be set for most functions to work properly.
+/// If the password is not set then the functions QLDevice_Start(), QLDevice_GetFrame(),
+/// QLDevice_GetStatus() and QLCalibration_Initialize() will return the value
+/// QL_ERROR_INVALID_PASSWORD.
+///
+/// @param [in] device   The ID of the device for which to set the password. This ID is obtained
+///                      by calling the function QLDevice_Enumerate().
+/// @param [in] password A pointer to a NULL-terminated string containing the password for the
+///                      device.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the password was
+/// valid and stored in the device.
+/// 
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_SetPassword(
+        QLDeviceId device, 
+        const char* password);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_Start( QLDeviceOrGroupId deviceOrGroup);
+///
+/// @ingroup Device
+/// @brief Start the device.
+/// 
+/// This function causes the device to start running. Once running, the device will grab and
+/// process frames as fast as the current settings allow. Calling this function on a device that
+/// has already been started will not restart the device. QLDevice_Stop() must be called before a
+/// device can be restarted.
+/// 
+/// Calling this function using a device group will cause all devices in the group to start.
+///
+/// @param [in] deviceOrGroup The ID of the device or device group to start. This ID is obtained by
+///                           calling either the function QLDevice_Enumerate() or the function
+///                           QLDeviceGroup_Create().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the device/group
+/// was started successfully.
+/// 
+/// @example /src/QuickStart/Main.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_Start(
+        QLDeviceOrGroupId deviceOrGroup);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_Stop( QLDeviceOrGroupId deviceOrGroup);
+///
+/// @ingroup Device
+/// @brief Stop the device.
+/// 
+/// This function causes the device to stop running. Before unloading the library, this function
+/// must be called for each device that has been started using the function QLDevice_Start().
+/// Undefined behavior could result if the library is unloaded before a device is stopped.
+/// 
+/// It is best if this function is called before a process has been signaled to exit. This will
+/// give a device sufficient time to clean up its memory and close its thread before the process
+/// exit procedure unloads the library automatically.
+/// 
+/// Calling this function using a device group will cause all devices in the group to stop.
+///
+/// @param [in] deviceOrGroup The ID of the device or device group to stop. This ID is obtained by
+///                           calling either the function QLDevice_Enumerate() or the function
+///                           QLDeviceGroup_Create().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the device/group
+/// was stopped successfully and all system resources used by the device(s) have been closed.
+///
+/// @example /src/QuickStart/Main.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_Stop(
+        QLDeviceOrGroupId deviceOrGroup);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_Stop_All();
+///
+/// @ingroup Device
+/// @brief Stop all devices.
+/// 
+/// This function causes all devices to stop running. Before unloading the library, each device
+/// that has been started by using the function QLDevice_Start() must be stopped. This can be
+/// done by calling QLDevice_Stop() for each device that has been started, or this function could
+/// be called to stop all devices. Undefined behavior could result if the library is unloaded
+/// before a device is stopped.
+/// 
+/// It is best if each device is stopped before a process has been signaled to exit. This will
+/// give a device sufficient time to clean up its memory and close its thread before the process
+/// exit procedure unloads the library automatically.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then all devices were
+/// stopped successfully and all system resources used by the devices have been closed.
+///
+/// @example /src/QuickStart/QL2Utility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_Stop_All();
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_SetIndicator( QLDeviceOrGroupId deviceOrGroup,
+/// QLIndicatorType type, QLIndicatorMode mode);
+///
+/// @ingroup Device
+/// @brief Set the indicator mode for the device.
+/// 
+/// This function sets the mode for the indicator lights on the front of the device.
+/// 
+/// Calling this function using a device group will sets the mode for the indicator lights on the
+/// front of all devices in the group.
+///
+/// @param [in] deviceOrGroup The ID of the device or device group whose indicator lights should be
+///                           set. This ID is obtained by calling either the function
+///                           QLDevice_Enumerate() or the function QLDeviceGroup_Create().
+/// @param [in] type          The type of indicator to set.
+/// @param [in] mode          The mode to set the indicator.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the indicator
+/// was set to the desired mode for the specified device(s).
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_SetIndicator(
+        QLDeviceOrGroupId deviceOrGroup, 
+        QLIndicatorType type, 
+        QLIndicatorMode mode);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_GetIndicator( QLDeviceId device,
+/// QLIndicatorType type, QLIndicatorMode* mode);
+///
+/// @ingroup Device
+/// @brief Get the current indicator mode for the device.
+/// 
+/// This function gets the current mode for the indicator lights on the front of the device.
+///
+/// @param [in] device The ID of the device from which to get the indicator mode. This ID is
+///                    obtained by calling the function QLDevice_Enumerate().
+/// @param [in] type   The type of indicator to get.
+/// @param [out] mode  A pointer to a QLIndicatorMode object. This object will receive the mode
+///                    of the indicator type for the specified device.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the indicator
+/// mode was retrieved from the specified device.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_GetIndicator(
+        QLDeviceId device, 
+        QLIndicatorType type, 
+        QLIndicatorMode* mode);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_GetFrame( QLDeviceOrGroupId deviceOrGroup,
+/// int waitTime, QLFrameData* frame);
+///
+/// @ingroup Device
+/// @brief Get a frame from the device
+/// 
+/// This function gets the most recent frame from the device. It is a blocking function which
+/// will wait for a frame to become available if there is not one ready. Waiting does not use CPU
+/// time.
+/// 
+/// Only the most recent frame can be retrieved from the device. To ensure that no frames are
+/// dropped this function needs to be called at least as fast as the frame rate of the device. A
+/// good way to use this function that will help ensure the retrieval of every frame is to use it
+/// in a loop. The blocking nature of this function will ensure that the loop will only run as
+/// fast as the device can produce frames. If other processing in the loop does not exceed the
+/// time that it takes for the device to make another frame available then this function will
+/// sync the loop to the approximate frame rate of the device.
+/// 
+/// Calling this function using a device group will get a frame from only one device in the
+/// group. If there are no devices that are tracking eyes then the image that is returned rotates
+/// between all devices in the group. Each device will be selected for 3 seconds before rotating
+/// to the next device. The order of rotation is based on the order in which the devices were
+/// added to the group. If a device in the group is tracking eyes then that device becomes the
+/// selected device. It will stay the selected device until the eyes are lost. Once a device
+/// begins tracking eyes and becomes the selected device, eye tracking is dissabled on all other
+/// devices in the group until the selected device loses the eyes. If two devices find eyes at
+/// the same time then the device that has eyes closest to the center of the image becomes the
+/// selected device.
+///
+/// @param [in] deviceOrGroup The ID of the device or device group from which to get the most
+///                           recent frame. This ID is obtained by calling either the function
+///                           QLDevice_Enumerate() or the function QLDeviceGroup_Create().
+/// @param [in] waitTime      The maximum time in milliseconds to wait for a new frame.
+/// @param [out] frame        A pointer to a QLFrameData object. This object receives the data for
+///                           the most recent frame.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the most recent
+/// frame was successfully retrieved from the device or group.
+/// 
+/// @see QLDeviceGroup_AddDevice()
+/// 
+/// @example /src/QuickStart/Main.cpp
+/// @example /src/QuickStart/DisplayVideo.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_GetFrame(
+        QLDeviceOrGroupId deviceOrGroup,
+        int waitTime, 
+        QLFrameData* frame);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_ApplyCalibration( QLDeviceId device,
+/// QLCalibrationId calibration);
+///
+/// @ingroup Device
+/// @brief Apply a calibration to a device.
+/// 
+/// This function applies a calibration to a device. If a calibration is not applied to a device
+/// then the gaze point can not be calculated. By applying a calibration object that has not been
+/// calibrated it is possible to clear a calibration from a device so it will be un-calibrated.
+/// 
+/// For greatest accuracy a device should be calibrated for each user, for each physical setup of
+/// the device and monitor.
+///
+/// @param [in] device      The ID of the device for which to apply the calibration. This ID is
+///                         obtained by calling the function QLDevice_Enumerate().
+/// @param [in] calibration The ID of the calibration object to apply. This ID is obtained by
+///                         calling either the function QLCalibration_Create() or the function
+///                         QLCalibration_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// was successfully applied to the device.
+/// 
+/// @see Calibration
+/// 
+/// @example /src/QuickStart/Main.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDevice_ApplyCalibration(
+        QLDeviceId device, 
+        QLCalibrationId calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDevice_CalibrateEyeRadius( QLDeviceId device,
+/// float distance, float* leftRadius, float* rightRadius);
+///
+/// @ingroup Device
+/// @brief Calibrate the radius for each eye.
+/// 
+/// This function uses the measured distance to the user in order to calculate the radius of the
+/// cornea for each eye. Using the radii returned by this function as the values for the settings
+/// QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT and
+/// QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT will result in greater accuracy of the
+/// distance output for each frame.
+///
+/// @param [in] device       The ID of the device from which to calibrate the eye radius.
+/// @param [in] distance     The actual measured distance in centimeters that the user is away
+///                          from the device at the time this function is called.
+/// @param [out] leftRadius  A pointer to a float that will receive the radius in centimeters of
+///                          the cornea of the left eye.
+/// @param [out] rightRadius A pointer to a float that will receive the radius in centimeters of
+///                          the cornea of the right eye.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the radius of
+/// the left and right eyes were successful.
+/// 
+/// @see QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT.
+/// @see QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN
+	QLDevice_CalibrateEyeRadius(
+		QLDeviceId device,
+		float distance,
+		float* leftRadius,
+		float* rightRadius);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDeviceGroup_Create( QLDeviceGroupId* deviceGroup);
+///
+/// @ingroup Device
+/// @brief Create a new device group and get its ID.
+/// 
+/// This function creates a new device group. A device group is used to perform actions on a
+/// number of devices at once instead of having to do it for each device individually. Many
+/// functions that accept a device ID can also be used with a group ID. See the function's
+/// documentation for verificaion.
+///
+/// @param [out] deviceGroup A pointer to a QLDeviceGroupId object. This object will receive the
+///                          ID of the new device group.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the device group
+/// was created successfully.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDeviceGroup_Create(
+        QLDeviceGroupId* deviceGroup);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDeviceGroup_AddDevice( QLDeviceGroupId deviceGroup,
+/// QLDeviceId device);
+///
+/// @ingroup Device
+/// @brief Add a device to a device group.
+/// 
+/// This function adds a device to the given device group. The order of the devices in the group
+/// is based on the order in which they were added to the group. Adding a device that is already
+/// in the group will cause it to be removed from its previous position and added to the end of
+/// the device list.
+///
+/// @param [in] deviceGroup The ID of the device group to which the device should be added.
+/// @param [in] device      The ID of the device that will be added to the device group.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the device was
+/// successfully added to the device group. QL_ERROR_OK will also be returned if the device was
+/// already in the group.
+/// 
+/// @see QLDeviceGroup_Create()
+/// @see QLDeviceGroup_RemoveDevice()
+/// @see QLDevice_Enumerate()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDeviceGroup_AddDevice(
+        QLDeviceGroupId deviceGroup, 
+        QLDeviceId device);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDeviceGroup_RemoveDevice( QLDeviceGroupId deviceGroup,
+/// QLDeviceId device);
+///
+/// @ingroup Device
+/// @brief Remove a device from a device group.
+/// 
+/// This function removes a device from the given device group.
+///
+/// @param [in] deviceGroup The ID of the device group from which the device should be removed.
+/// @param [in] device      The ID of the device that will be removed from the device group.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the device was
+/// successfully removed from the device group. QL_ERROR_OK will also be returned if the device
+/// was already missing from the group.
+/// 
+/// @see QLDeviceGroup_Create()
+/// @see QLDeviceGroup_AddDevice()
+/// @see QLDevice_Enumerate()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDeviceGroup_RemoveDevice(
+        QLDeviceGroupId deviceGroup, 
+        QLDeviceId device);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDeviceGroup_Enumerate( QLDeviceGroupId deviceGroup,
+/// int* numDevices, QLDeviceId* deviceBuffer);
+///
+/// @ingroup Device
+/// @brief Enumerate the device group.
+/// 
+/// This function enumerates the device group and retrieves a list of device IDs that are part of
+/// the group. The order of the devices in the buffer is based on the order in which the devices
+/// were added to the group.
+///
+/// @param [in] deviceGroup    The ID of the device group to enumerate.
+/// @param [in,out] numDevices A pointer to an integer containing the size of deviceBuffer. When
+///                            the function returns the integer contains the number of devices
+///                            found on the bus.
+/// @param [out] deviceBuffer  A pointer to a QLDeviceId buffer that will receive the IDs of the
+///                            devices that are in the device group.
+///
+/// @return The success of the function. If the return value is QL_ERROR_BUFFER_TOO_SMALL then
+/// the device buffer was too small to contain all the devices that are in the group. numDevices
+/// will contain the number of devices in the group and the deviceBuffer should be resized to be
+/// at least this large before this function is called again. If the return value is QL_ERROR_OK
+/// then the group was successfully enumerated and the device buffer contains IDs for all the
+/// devices that are in the group.
+///
+/// @see QLDeviceGroup_AddDevice()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDeviceGroup_Enumerate(
+        QLDeviceGroupId deviceGroup, 
+        int* numDevices,
+        QLDeviceId* deviceBuffer);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLDeviceGroup_GetFrame( QLDeviceGroupId deviceGroup,
+/// int waitTime, int* numFrames, QLFrameData* frame);
+///
+/// @ingroup Device
+/// @brief Get frames from all devices in the group.
+/// 
+/// This function gets the most recent frame from each device in the device group. It is a
+/// blocking function which will wait for a frame to become available on each device before
+/// returning. Waiting does not use CPU time. The ordering of the frames will be based on the
+/// the order in which the devices were added to the group. The order can be recalled by
+/// enumerating the group with the function QLDeviceGroup_Enumerate().
+///
+/// @param [in] deviceGroup   The ID of the device group whose devices will be queried for frames.
+/// @param [in] waitTime      The maximum time in milliseconds to wait for a new frame from a
+///                           single device. This time is used for blocking each device which
+///                           means that the total time the function could possibly block can
+///                           be larger than this time.
+/// @param [in,out] numFrames A pointer to an integer containing the size of frame buffer. This
+///                           should be at least as large as the number of devices in the
+///                           group. When the function returns the integer contains the number
+///                           of frames used in the frame buffer and will equal the number of
+///                           devices in the group.
+/// @param [out] frame        A pointer to a QLFrameData buffer that will receive the frames from
+///                           the devices in the group.
+///
+/// @return The success of the function. If the return value is QL_ERROR_BUFFER_TOO_SMALL then
+/// the frame buffer was too small to contain the frames from all the devices in the group.
+/// numFrames will contain the number of devices in the group and the frame buffer should be
+/// resized to be at least this large before this function is called again. If the return value
+/// is QL_ERROR_OK then the frames were successfully collected from all devices in the group.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLDeviceGroup_GetFrame(
+        QLDeviceGroupId deviceGroup,
+        int waitTime, 
+        int* numFrames,
+        QLFrameData* frame);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_Load( const char* path,
+/// QLSettingsId* settings);
+///
+/// @ingroup Settings
+/// @brief Load settings from a file into a settings container.
+/// 
+/// This function loads settings from a file into a settings container. If there are settings in
+/// the file that are currently in the settings container then the values from the file will
+/// overwrite the current values. If a setting is in the file multiple times with different
+/// values, the last entry takes precedence.
+///
+/// @param [in] path         A NULL-terminated string containing the full pathname of the settings
+///                          file.
+/// @param [in,out] settings A pointer to a QLSettingsId object. If the QLSettingsId object refers
+///                          to a valid settings container then that settings container will
+///                          receive the loaded settings. If the QLSettingsId object does not
+///                          refer to a valid settings container then a new settings container
+///                          will be created and this object will receive its ID.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// were successfully loaded.
+/// 
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_Load(
+        const char* path, 
+        QLSettingsId* settings);
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_Save( const char* path,
+/// QLSettingsId settings);
+///
+/// @ingroup Settings
+/// @brief Save settings from a settings container to a file.
+/// 
+/// This function saves the settings of a settings container to a file. If the file already
+/// exists then its contents are modified. Only the values of the settings that are in the
+/// settings container are changed. New settings are added to the end of the file. If the file
+/// did not previously exist then a new file is created.
+///
+/// @param [in] path     A NULL-terminated string containing the full pathname of the settings
+///                      file.
+/// @param [in] settings The ID of the settings container containing the settings to save.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the settings
+/// were successfully saved.
+/// 
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_Save(
+        const char* path, 
+        QLSettingsId settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_Create( QLSettingsId source,
+/// QLSettingsId* settings);
+///
+/// @ingroup Settings
+/// @brief Create a new settings container.
+/// 
+/// This function creates a new settings container. If the source ID references a valid settings
+/// container then its contents will be copied into the newly created settings container. If the
+/// source ID does not reference a valid settings container then the new settings container will
+/// be empty.
+/// 
+/// If settings ID pointer references a QLSettingsId that has already been created then the container
+/// associated with this ID will be cleared first.
+///
+/// @param [in] source       The ID of the settings container from which to copy settings. This ID
+///                          is obtained by calling either this function or the function
+///                          QLSettings_Load(). To create an empty settings container, set this
+///                          value to zero.
+/// @param [in,out] settings A pointer to a QLSettingsId object. This object will receive the ID
+///                          of the new settings container.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the new settings
+/// container was successfully created.
+///
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_Create(
+        QLSettingsId source, 
+        QLSettingsId* settings);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_AddSetting( QLSettingsId settings,
+/// const char* settingName);
+///
+/// @ingroup Settings
+/// @brief Add a setting to a settings container.
+/// 
+/// This function adds a setting to a settings container and gives it an initial value of zero.
+/// If the setting already exists in the settings container then its value remains unchanged.
+///
+/// @param [in] settings    The ID of the settings container that will receive the new setting.
+///                         This ID is obtained by calling either the function
+///                         QLSettings_Create() or the function QLSettings_Load().
+/// @param [in] settingName A NULL terminated string containing the name of the setting to add to
+///                         the settings container.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the setting was
+/// successfully added to the settings container or the setting was already in the settings
+/// container.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_AddSetting(
+        QLSettingsId settings,
+        const char* settingName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_RemoveSetting( QLSettingsId settings,
+/// const char* settingName);
+///
+/// @ingroup Settings
+/// @brief Remove a setting from a settings container.
+/// 
+/// This function removes a setting from a settings container.
+///
+/// @param [in] settings    The ID of the settings container from which the setting will be
+///                         removed. This ID is obtained by calling either the function
+///                         QLSettings_Create() or the function QLSettings_Load().
+/// @param [in] settingName A NULL terminated string containing the name of the setting that will
+///                         be removed from the settings container.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the setting was
+/// successfully removed from the settings container. If the return value is QL_ERROR_NOT_FOUND
+/// then the setting was not in the container.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_RemoveSetting(
+        QLSettingsId settings,
+        const char* settingName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValue( QLSettingsId settings,
+/// const char* settingName, QLSettingType settingType, const void* value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container.
+/// 
+/// This function sets the value of a setting in a settings container. If the setting already
+/// existed in the settings container then its value is updated. If the setting did not already
+/// exist in the settings container then it is added with the specified value.
+///
+/// @param [in] settings    The ID of the settings container that either contains the setting to
+///                         be altered or will receive the new setting if it did not exist
+///                         previously. This ID is obtained by calling either the function
+///                         QLSettings_Create() or the function QLSettings_Load().
+/// @param [in] settingName A NULL terminated string containing the name of the setting that will
+///                         be altered in, or added to, the settings container.
+/// @param [in] settingType The type of data that was passed in. This tells the API how to
+///                         interpret the data pointed to by "value".
+/// @param [in] value       A pointer to an object which contains the value to set the setting.
+///                         The object type must match the type indicated by "settingType". For
+///                         the type QL_SETTING_TYPE_STRING this must be a NULL terminated string
+///                         containing the desired value.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the setting
+/// value was successfully updated or the setting was successfully added to the settings
+/// container.
+///
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_SetValue(
+        QLSettingsId settings,
+        const char* settingName,
+        QLSettingType settingType,
+        const void* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueInt( QLSettingsId settings,
+/// const char* settingName, int value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueInt(
+		QLSettingsId settings, 
+		const char* settingName, 
+		int value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueInt8( QLSettingsId settings,
+/// const char* settingName, __int8 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT8. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueInt8(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int8 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueInt16( QLSettingsId settings,
+/// const char* settingName, __int16 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT16. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueInt16(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int16 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueInt32( QLSettingsId settings,
+/// const char* settingName, __int32 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT32. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueInt32(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int32 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueInt64( QLSettingsId settings,
+/// const char* settingName, __int64 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT64. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueInt64(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int64 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueUInt( QLSettingsId settings,
+/// const char* settingName, unsigned int value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueUInt(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned int value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueUInt8( QLSettingsId settings,
+/// const char* settingName, unsigned __int8 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT8. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueUInt8(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int8 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueUInt16( QLSettingsId settings,
+/// const char* settingName, unsigned __int16 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT16. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueUInt16(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int16 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueUInt32( QLSettingsId settings,
+/// const char* settingName, unsigned __int32 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT32. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueUInt32(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int32 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueUInt64( QLSettingsId settings,
+/// const char* settingName, unsigned __int64 value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT64. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueUInt64(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int64 value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueFloat( QLSettingsId settings,
+/// const char* settingName, float value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_FLOAT. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueFloat(
+		QLSettingsId settings, 
+		const char* settingName, 
+		float value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueDouble( QLSettingsId settings,
+/// const char* settingName, double value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_DOUBLE. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueDouble(
+		QLSettingsId settings, 
+		const char* settingName, 
+		double value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueBool( QLSettingsId settings,
+/// const char* settingName, bool value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_BOOL. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueBool(
+		QLSettingsId settings, 
+		const char* settingName, 
+		bool value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueVoidPointer( QLSettingsId settings,
+/// const char* settingName, void* value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_VOID_POINTER. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueVoidPointer(
+		QLSettingsId settings, 
+		const char* settingName, 
+		void* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_SetValueString( QLSettingsId settings,
+/// const char* settingName, char* value);
+///
+/// @ingroup Settings
+/// @brief Set the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_STRING. This is a wrapper for QLSettings_SetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_SetValueString(
+		QLSettingsId settings, 
+		const char* settingName, 
+		char* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValue( QLSettingsId settings,
+/// const char* settingName, QLSettingType settingType, int size, void* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container.
+/// 
+/// This function gets the value of a setting in a settings container if the setting exists.
+///
+/// @param [in] settings    The ID of the settings container from which to get the value. This ID
+///                         is obtained by calling either the function QLSettings_Create() or the
+///                         function QLSettings_Load().
+/// @param [in] settingName A NULL terminated string containing the name of the setting whose
+///                         value will be retrieved.
+/// @param [in] settingType The type of data object that was passed in. This tells the API how to
+///                         interpret the object pointed to by "value".
+/// @param [in] size        If the type is QL_SETTING_TYPE_STRING then this is the size of the
+///                         buffer pointed to by "value". For other types this is not used.
+/// @param [out] value      A pointer to an object that will receive the value of the setting.
+///                         The object type must match the type indicated by "settingType". For
+///                         the type QL_SETTING_TYPE_STRING this must be a char array at least as
+///                         large as "size".
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the setting
+/// value was successfully retrieved.
+/// 
+/// @example /src/QuickStart/Initialize.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_GetValue(
+        QLSettingsId settings,
+        const char* settingName,
+        QLSettingType settingType,
+        int size,
+        void* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueInt( QLSettingsId settings,
+/// const char* settingName, int* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueInt(
+		QLSettingsId settings, 
+		const char* settingName, 
+		int* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueInt8( QLSettingsId settings,
+/// const char* settingName, __int8* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT8. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueInt8(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int8* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueInt16( QLSettingsId settings,
+/// const char* settingName, __int16* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT16. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueInt16(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int16* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueInt32( QLSettingsId settings,
+/// const char* settingName, __int32* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT32. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueInt32(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int32* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueInt64( QLSettingsId settings,
+/// const char* settingName, __int64* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_INT64. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueInt64(
+		QLSettingsId settings, 
+		const char* settingName, 
+		__int64* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueUInt( QLSettingsId settings,
+/// const char* settingName, unsigned int* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueUInt(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned int* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueUInt8( QLSettingsId settings,
+/// const char* settingName, unsigned __int8* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT8. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueUInt8(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int8* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueUInt16( QLSettingsId settings,
+/// const char* settingName, unsigned __int16* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT16. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueUInt16(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int16* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueUInt32( QLSettingsId settings,
+/// const char* settingName, unsigned __int32* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT32. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueUInt32(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int32* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueUInt64( QLSettingsId settings,
+/// const char* settingName, unsigned __int64* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_UINT64. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueUInt64(
+		QLSettingsId settings, 
+		const char* settingName, 
+		unsigned __int64* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueFloat( QLSettingsId settings,
+/// const char* settingName, float* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_FLOAT. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueFloat(
+		QLSettingsId settings, 
+		const char* settingName, 
+		float* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueDouble( QLSettingsId settings,
+/// const char* settingName, double* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_DOUBLE. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueDouble(
+		QLSettingsId settings, 
+		const char* settingName, 
+		double* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueBool( QLSettingsId settings,
+/// const char* settingName, bool* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_BOOL. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueBool(
+		QLSettingsId settings, 
+		const char* settingName, 
+		bool* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueVoidPointer( QLSettingsId settings,
+/// const char* settingName, void** value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_VOID_POINTER. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_SetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueVoidPointer(
+		QLSettingsId settings, 
+		const char* settingName, 
+		void** value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueString( QLSettingsId settings,
+/// const char* settingName, int size, char* value);
+///
+/// @ingroup Settings
+/// @brief Get the value of a setting in a settings container using the setting type
+/// QL_SETTING_TYPE_STRING. This is a wrapper for QLSettings_GetValue().
+/// 
+/// @see QLSettings_GetValue()
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+	QLSettings_GetValueString(
+		QLSettingsId settings,
+		const char* settingName, 
+		int size, 
+		char* value);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLSettings_GetValueStringSize( QLSettingsId settings,
+/// const char* settingName, int* size);
+///
+/// @ingroup Settings
+/// @brief Get the string size of the setting value.
+/// 
+/// This function gets the size of the string, including the terminating NULL character, for the
+/// specified setting's value. A buffer would have to be at least as large as the value returned
+/// by "size" to successfully get a value of type QL_SETTING_TYPE_STRING using the function
+/// QLSettings_GetValue().
+///
+/// @param [in] settings    The ID of the settings container from which to get the value's string
+///                         length. This ID is obtained by calling either the function
+///                         QLSettings_Create() or the function QLSettings_Load().
+/// @param [in] settingName A NULL terminated string containing the name of the setting whose
+///                         value's string length will be retrieved.
+/// @param [out] size       A pointer to an object that will receive the string length of the
+///                         value.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the string
+/// length for the setting value was successfully retrieved.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLSettings_GetValueStringSize(
+        QLSettingsId settings,
+        const char* settingName,
+        int* size);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Load( const char* path,
+/// QLCalibrationId* calibration);
+///
+/// @ingroup Calibration
+/// @brief Load calibration data from a file.
+/// 
+/// This function loads calibration data from a file into a calibration container. The file must
+/// have been created by calling the function QLCalibration_Save().
+///
+/// @param [in] path            A NULL-terminated string containing the full pathname of the
+///                             calibration file.
+/// @param [in,out] calibration A pointer to a QLCalibrationId object. If the QLCalibrationId
+///                             object refers to a valid calibration container then that
+///                             calibration container will receive the loaded calibration. If the
+///                             QLCalibrationId object does not refer to a valid calibration
+///                             container then a new calibration container will be created and
+///                             this object will receive its ID.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// was successfully loaded.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Load(
+        const char* path, 
+        QLCalibrationId* calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Save( const char* path,
+/// QLCalibrationId calibration);
+///
+/// @ingroup Calibration
+/// @brief Save calibration data to a file.
+/// 
+/// This function saves calibration data to a file. The calibration data can later be loaded by
+/// calling the function QLCalibration_Load().
+///
+/// @param [in] path        A NULL-terminated string containing the full pathname of the
+///                         calibration file.
+/// @param [in] calibration The ID of the calibration container whose data will be saved. This ID
+///                         is obtained by calling either the function QLCalibration_Create() or
+///                         the function QLCalibration_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// was successfully saved.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Save(
+        const char* path, 
+        QLCalibrationId calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Create( QLCalibrationId source,
+/// QLCalibrationId* calibration);
+///
+/// @ingroup Calibration
+/// @brief Create a new calibration container.
+/// 
+/// This function creates a new calibration container. If the source ID references a valid
+/// calibration container then its data will be copied into the newly created calibration
+/// container. If the source ID does not reference a valid settings container then the new
+/// settings container will be empty.
+///
+/// @param [in] source       The ID of the calibration container from which to copy calibration
+///                          data. This ID is obtained by calling either this function or the
+///                          function QLCalibration_Load(). To create an empty settings container,
+///                          set this value to zero.
+/// @param [out] calibration A pointer to a QLCalibrationId object. This object will receive the
+///                          ID of the newly created calibration container.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the new
+/// calibration container was successfully created.
+/// 
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Create(
+        QLCalibrationId source,
+        QLCalibrationId* calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Initialize( QLDeviceId device,
+/// QLCalibrationId calibration, QLCalibrationType type);
+///
+/// @ingroup Calibration
+/// @brief Initialize a calibration container.
+/// 
+/// This function initializes a calibration container which makes it ready to receive new
+/// calibration data from a device. Any calibration data previously in the container is stored in
+/// temporary memory until QLCalibration_Finalize() is called.
+///
+/// @param [in] device      The ID of the device from which to receive calibration data. This ID
+///                         is obtained by calling the function QLDevice_Enumerate().
+/// @param [in] calibration The ID of the calibration container that will receive the new
+///                         calibration data. This ID is obtained by calling either the function
+///                         QLCalibration_Create() or the function QLCalibration_Load().
+/// @param [in] type        The type of calibration to perform.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// container was successfully initialized and is now ready to receive new calibration data.
+/// 
+/// @see Device
+/// 
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Initialize(
+        QLDeviceId device, 
+        QLCalibrationId calibration, 
+        QLCalibrationType type);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_GetTargets( QLCalibrationId calibration,
+/// int* numTargets, QLCalibrationTarget* targets);
+///
+/// @ingroup Calibration
+/// @brief Get the positions for the calibration targets.
+/// 
+/// This function gets the locations and IDs of the targets for the calibration. It can be called
+/// to retrieve target positions from a calibration container that is calibrating or one that has
+/// already been finalized.
+///
+/// @param [in] calibration    The ID of a calibration container from which to get the target
+///                            data. This ID is obtained by calling either the function
+///                            QLCalibration_Create() or the function QLCalibration_Load().
+/// @param [in,out] numTargets A pointer to an integer containing the size of the target buffer
+///                            pointed to by "targets". When the function returns this contains
+///                            the number of targets for the calibration.
+/// @param [out] targets       A pointer to a QLCalibrationTarget buffer that will receive the
+///                            data for the calibration points.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the target
+/// positions were successfully retrieved.
+///
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_GetTargets(
+        QLCalibrationId calibration, 
+        int* numTargets,
+        QLCalibrationTarget* targets);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Calibrate( QLCalibrationId calibration,
+/// QLTargetId target, int duration, bool block);
+///
+/// @ingroup Calibration
+/// @brief Calibrate a target.
+/// 
+/// This function causes the calibration container to collect data from a device for a specific
+/// target location. It should be called at least once for each target that was received by
+/// calling the function QLCalibration_GetTargets(). If this function is called multiple times
+/// for the same target and not all targets have been calibrated then the data collected by the
+/// last call will overwrite previous data. If this function is called multiple times for the
+/// same target and all targets have been calibrated then the data collected by the last call
+/// will only overwrite the previous data if it improves the calibration overall.
+/// 
+/// This function must be called for each target after a calibration has been initialized but
+/// before it has been finalized.
+///
+/// @param [in] calibration The ID of a calibration container which has been initialized and is
+///                         ready to receive calibration data. This ID is obtained by calling
+///                         either the function QLCalibration_Create() or the function
+///                         QLCalibration_Load().
+/// @param [in] target      The ID of a target that the user is looking at. This ID is obtained
+///                         by calling the function QLCalibration_GetTargets(). Usually there
+///                         should be a target drawn on the screen at the location referenced by
+///                         this target before calling this function.
+/// @param [in] duration    The length of time that the API will collect calibration data. For
+///                         best results the user should be looking at the target position the
+///                         entire time.
+/// @param [in] block       A flag to determine whether this function should block. If this is
+///                         true then the function will block and not return until the API is
+///                         done collecting data for the calibration point. If this is false then
+///                         this function will return immediately and the status of the data
+///                         collection can be determined by calling the function
+///                         QLCalibration_GetStatus().
+///
+/// @return The success of the function. If the function blocks then a return value of
+/// QL_ERROR_OK means that the duration has finished and that data was gathered for the target.
+/// If the function does not block then a return value of QL_ERROR_OK means that calibration data
+/// collection was successfully started for the target.
+///
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Calibrate(
+        QLCalibrationId calibration, 
+        QLTargetId target, 
+        int duration, 
+        bool block);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_GetScoring( QLCalibrationId calibration,
+/// QLTargetId target, QLEyeType eye, QLCalibrationScore* score);
+///
+/// @ingroup Calibration
+/// @brief Get the scoring of a calibration target.
+/// 
+/// This function gets the the score of a calibration target for a particular eye. The eye must
+/// have been detected at least once for each target of the calibration in order to produce a
+/// score.
+/// 
+/// This function can be called before or after a calibration has been finalized.
+///
+/// @param [in] calibration The ID of a calibration container whose data will be used to
+///                         calculate a score. This ID is obtained by calling either the function
+///                         QLCalibration_Create() or the function QLCalibration_Load().
+/// @param [in] target      The ID of a target whose score will be retrieved. This ID is obtained
+///                         by calling the function QLCalibration_GetTargets().
+/// @param [in] eye         The eye whose score should be retrieved.
+/// @param [out] score      A pointer to a QLCalibrationScore object that will receive the score.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the score was
+/// successfully retrieved. If the return value is QL_ERROR_INTERNAL_ERROR then use the function
+/// QLCalibration_GetStatus()
+/// to get extended error information().
+/// 
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_GetScoring(
+        QLCalibrationId calibration, 
+        QLTargetId target, 
+        QLEyeType eye, 
+        QLCalibrationScore* score);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_GetStatus( QLCalibrationId calibration,
+/// QLTargetId target, QLCalibrationStatus* calibrationStatus);
+///
+/// @ingroup Calibration
+/// @brief Get the status of a calibration target.
+/// 
+/// This function retrieves the status of a calibration target for a given calibration container.
+/// It can be called before or after a calibration has been finalized.
+///
+/// @param [in] calibration        The ID of a calibration container whose data will be used to
+///                                determine a status for the target. This ID is obtained by
+///                                calling either the function QLCalibration_Create() or the
+///                                function QLCalibration_Load().
+/// @param [in] target             The ID of a target whose status will be retrieved. This ID is
+///                                obtained by calling the function QLCalibration_GetTargets().
+/// @param [out] calibrationStatus A pointer to a QLCalibrationStatus object that will receive
+///                                the status.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// status for the target was successfully retrieved.
+/// 
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_GetStatus(
+        QLCalibrationId calibration,
+        QLTargetId target,
+        QLCalibrationStatus* calibrationStatus);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Finalize( QLCalibrationId calibration);
+///
+/// @ingroup Calibration
+/// @brief Finalize a completed calibration.
+/// 
+/// This function finalizes a calibration after it is complete. It should be called when
+/// calibration data has been successfully collected at each target position and the target
+/// scores meet the user requirements.
+/// 
+/// This function clears any previous calibration data that was stored in the container and
+/// replaces it with the new calibration data.
+///
+/// @param [in] calibration The ID of a calibration container to finalize. This ID is obtained by
+///                         calling either the function QLCalibration_Create() or the function
+///                         QLCalibration_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// was successfully finalized.
+///
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Finalize(
+        QLCalibrationId calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_Cancel( QLCalibrationId calibration);
+///
+/// @ingroup Calibration
+/// @brief Cancel a calibration that is in process.
+/// 
+/// This function cancels a calibration. Recently collected calibration data is cleared and the
+/// calibration container is restored to the state it was in before QLCalibration_Initialize()
+/// was called.
+///
+/// @param [in] calibration The ID of a calibration container to cancel. This ID is obtained by
+///                         calling either the function QLCalibration_Create() or the function
+///                         QLCalibration_Load().
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the calibration
+/// was successfully canceled.
+/// 
+/// @example /src/QuickStart/Calibrate.cpp
+/// @example /src/QuickStart/OpencvUtility.cpp.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_Cancel(
+        QLCalibrationId calibration);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @fn QLError QUICK_LINK_2_CALL_CONVEN QLCalibration_AddBias( QLCalibrationId calibration,
+/// QLEyeType eye, float xOffset, float yOffset);
+///
+/// @ingroup Calibration
+/// @brief Add a bias to the data in the calibration container.
+///
+/// @param [in] calibration The ID of a calibration container to which the bias will be added.
+///                         This ID is obtained by calling either the function
+///                         QLCalibration_Create() or the function QLCalibration_Load().
+/// @param [in] eye         The eye to which the bias should be added.
+/// @param [in] xOffset     The percent of the screen in the x direction that the bias should
+///                         affect the gaze point. Negative values will cause the resulting gaze
+///                         point to be left of the current position. Positive values will cause
+///                         the resulting gaze point to be right of the current position.
+/// @param [in] yOffset     The percent of the screen in the Y direction that the bias should
+///                         affect the gaze point. Negative values will cause the resulting gaze
+///                         point to be above the current position. Positive values will cause
+///                         the resulting gaze point to be below the current position.
+///
+/// @return The success of the function. If the return value is QL_ERROR_OK then the bias was
+/// successfully added to the calibration container.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+QLError QUICK_LINK_2_CALL_CONVEN 
+    QLCalibration_AddBias(
+        QLCalibrationId calibration, 
+        QLEyeType eye, 
+        float xOffset, 
+        float yOffset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QuickLink2_ptr_C.h
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/QuickLink2_ptr_C.h
@@ -1,0 +1,355 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file   QuickLink2_ptr_C.h
+///
+/// @brief This file contains definitions of function pointers for all
+/// functions available through QuickLink2.dll. This is useful for explicit
+/// linking.
+/// 
+/// @copyright 1996 - 2012, EyeTech Digital Systems
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#ifndef QUICK_LINK_2_PTR_C_H
+#define	QUICK_LINK_2_PTR_C_H
+
+#include "QLTypes.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN * ) QLAPI_GetVersion_Ptr (    int bufferSize,     char* buffer);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLAPI_ExportSettings_Ptr)(
+    QLSettingsId settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLAPI_ImportSettings_Ptr)(
+    QLSettingsId settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_Enumerate_Ptr)(
+    int* numDevices, 
+    QLDeviceId* deviceBuffer);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_GetInfo_Ptr)(
+    QLDeviceId device, 
+    QLDeviceInfo* info);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_GetStatus_Ptr)(
+    QLDeviceId device, 
+    QLDeviceStatus* status);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_ExportSettings_Ptr)(
+    QLDeviceId device, 
+    QLSettingsId settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_ImportSettings_Ptr)(
+    QLDeviceOrGroupId deviceOrGroup, 
+    QLSettingsId settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_IsSettingSupported_Ptr)(
+    QLDeviceId device, 
+    const char* settingName);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_SetPassword_Ptr)(
+    QLDeviceId device, 
+    const char* password);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_Start_Ptr)(
+    QLDeviceOrGroupId deviceOrGroup);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_Stop_Ptr)(
+    QLDeviceOrGroupId deviceOrGroup);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_Stop_All_Ptr)();
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_SetIndicator_Ptr)(
+    QLDeviceOrGroupId deviceOrGroup, 
+    QLIndicatorType type, 
+    QLIndicatorMode mode);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_GetIndicator_Ptr)(
+    QLDeviceId device, 
+    QLIndicatorType type, 
+    QLIndicatorMode* mode);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_GetFrame_Ptr)(
+    QLDeviceOrGroupId deviceOrGroup,
+	int waitTime,
+    QLFrameData* frame);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_ApplyCalibration_Ptr)(
+    QLDeviceId device, 
+    QLCalibrationId calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDevice_CalibrateEyeRadius_Ptr)(
+		QLDeviceId device,
+		float distance,
+		float* leftRadius,
+		float* rightRadius);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDeviceGroup_Create_Ptr)(
+		QLDeviceGroupId *deviceGroupId);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDeviceGroup_AddDevice_Ptr)(
+        QLDeviceGroupId deviceGroup, 
+        QLDeviceId deviceId);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDeviceGroup_RemoveDevice_Ptr)(
+        QLDeviceGroupId deviceGroup, 
+        QLDeviceId deviceId);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDeviceGroup_Enumerate_Ptr)(
+        QLDeviceGroupId deviceGroup, 
+        int *numDevices,
+        QLDeviceId *deviceIdBuffer);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLDeviceGroup_GetFrame_Ptr)(
+        QLDeviceGroupId deviceGroup,
+        int waitTime, 
+        int* numFrames,
+        QLFrameData* frame);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_Load_Ptr)(
+    const char* path, 
+    QLSettingsId* settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_Save_Ptr)(
+    const char* path, 
+    QLSettingsId settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_Create_Ptr)(
+    QLSettingsId source, 
+    QLSettingsId* settings);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_AddSetting_Ptr)(
+    QLSettingsId settings,
+    const char* settingName);
+	
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_RemoveSetting_Ptr)(
+    QLSettingsId settings,
+    const char* settingName);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValue_Ptr)(
+    QLSettingsId settings,
+    const char* settingName,
+    QLSettingType settingType,
+    const void* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueInt_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    int value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueInt8_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int8 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueInt16_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int16 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueInt32_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int32 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueInt64_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int64 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueUInt_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned int value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueUInt8_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int8 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueUInt16_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int16 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueUInt32_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int32 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueUInt64_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int64 value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueFloat_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    float value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueDouble_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    double value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueBool_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    bool value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueVoidPointer_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    void* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_SetValueString_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    char * value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValue_Ptr)(
+    QLSettingsId settings,
+    const char* settingName,
+    QLSettingType settingType,
+    int size,
+    void* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueInt_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    int* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueInt8_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int8* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueInt16_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int16* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueInt32_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int32* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueInt64_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    __int64* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueUInt_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned int* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueUInt8_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int8* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueUInt16_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int16* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueUInt32_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int32* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueUInt64_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    unsigned __int64* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueFloat_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    float* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueDouble_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    double* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueBool_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    bool* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueVoidPointer_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    void** value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueString_Ptr)(
+    QLSettingsId settings, 
+    const char* settingName, 
+    int size, 
+    char* value);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLSettings_GetValueStringSize_Ptr)(
+    QLSettingsId settings,
+    const char* settingName,
+    int* size);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Load_Ptr)(
+    const char* path, 
+    QLCalibrationId* calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Save_Ptr)(
+    const char* path, 
+    QLCalibrationId calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Create_Ptr)(
+    QLCalibrationId source,
+	QLCalibrationId* calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Initialize_Ptr)(
+    QLDeviceId device, 
+    QLCalibrationId calibration, 
+    QLCalibrationType type);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_GetTargets_Ptr)(
+    QLCalibrationId calibration, 
+    int* numTargets,
+    QLCalibrationTarget* targets);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Calibrate_Ptr)(
+    QLCalibrationId calibration, 
+    QLTargetId target, 
+    int duration, 
+    bool block);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_GetScoring_Ptr)(
+    QLCalibrationId calibration, 
+	QLTargetId target, 
+    QLEyeType eye, 
+    QLCalibrationScore* score);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_GetStatus_Ptr)(
+    QLCalibrationId calibration,
+    QLTargetId target,
+    QLCalibrationStatus* calibrationStatus);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Finalize_Ptr)(
+    QLCalibrationId calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_Cancel_Ptr)(
+    QLCalibrationId calibration);
+
+typedef QLError (QUICK_LINK_2_CALL_CONVEN* QLCalibration_AddBias_Ptr)(
+    QLCalibrationId calibration, 
+    QLEyeType eye, 
+    float xOffset, 
+    float yOffset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/pyQuickLink2.py
+++ b/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/pyQuickLink2.py
@@ -1,0 +1,1172 @@
+'''Wrapper for QuickLink2.h
+
+Generated with:
+ctypesgen.py -a -l QuickLink2 -o pyQuickLink2.py QuickLink2.h
+
+Do not modify this file.
+'''
+
+__docformat__ =  'restructuredtext'
+
+# Begin preamble
+
+import ctypes, os, sys
+from ctypes import *
+
+_int_types = (c_int16, c_int32)
+if hasattr(ctypes, 'c_int64'):
+    # Some builds of ctypes apparently do not have c_int64
+    # defined; it's a pretty good bet that these builds do not
+    # have 64-bit pointers.
+    _int_types += (c_int64,)
+for t in _int_types:
+    if sizeof(t) == sizeof(c_size_t):
+        c_ptrdiff_t = t
+del t
+del _int_types
+
+class c_void(Structure):
+    # c_void_p is a buggy return type, converting to int, so
+    # POINTER(None) == c_void_p is actually written as
+    # POINTER(c_void), so it can be treated as a real pointer.
+    _fields_ = [('dummy', c_int)]
+
+def POINTER(obj):
+    p = ctypes.POINTER(obj)
+
+    # Convert None to a real NULL pointer to work around bugs
+    # in how ctypes handles None on 64-bit platforms
+    if not isinstance(p.from_param, classmethod):
+        def from_param(cls, x):
+            if x is None:
+                return cls()
+            else:
+                return x
+        p.from_param = classmethod(from_param)
+
+    return p
+
+class UserString:
+    def __init__(self, seq):
+        if isinstance(seq, basestring):
+            self.data = seq
+        elif isinstance(seq, UserString):
+            self.data = seq.data[:]
+        else:
+            self.data = str(seq)
+    def __str__(self): return str(self.data)
+    def __repr__(self): return repr(self.data)
+    def __int__(self): return int(self.data)
+    def __long__(self): return long(self.data)
+    def __float__(self): return float(self.data)
+    def __complex__(self): return complex(self.data)
+    def __hash__(self): return hash(self.data)
+
+    def __cmp__(self, string):
+        if isinstance(string, UserString):
+            return cmp(self.data, string.data)
+        else:
+            return cmp(self.data, string)
+    def __contains__(self, char):
+        return char in self.data
+
+    def __len__(self): return len(self.data)
+    def __getitem__(self, index): return self.__class__(self.data[index])
+    def __getslice__(self, start, end):
+        start = max(start, 0); end = max(end, 0)
+        return self.__class__(self.data[start:end])
+
+    def __add__(self, other):
+        if isinstance(other, UserString):
+            return self.__class__(self.data + other.data)
+        elif isinstance(other, basestring):
+            return self.__class__(self.data + other)
+        else:
+            return self.__class__(self.data + str(other))
+    def __radd__(self, other):
+        if isinstance(other, basestring):
+            return self.__class__(other + self.data)
+        else:
+            return self.__class__(str(other) + self.data)
+    def __mul__(self, n):
+        return self.__class__(self.data*n)
+    __rmul__ = __mul__
+    def __mod__(self, args):
+        return self.__class__(self.data % args)
+
+    # the following methods are defined in alphabetical order:
+    def capitalize(self): return self.__class__(self.data.capitalize())
+    def center(self, width, *args):
+        return self.__class__(self.data.center(width, *args))
+    def count(self, sub, start=0, end=sys.maxint):
+        return self.data.count(sub, start, end)
+    def decode(self, encoding=None, errors=None): # XXX improve this?
+        if encoding:
+            if errors:
+                return self.__class__(self.data.decode(encoding, errors))
+            else:
+                return self.__class__(self.data.decode(encoding))
+        else:
+            return self.__class__(self.data.decode())
+    def encode(self, encoding=None, errors=None): # XXX improve this?
+        if encoding:
+            if errors:
+                return self.__class__(self.data.encode(encoding, errors))
+            else:
+                return self.__class__(self.data.encode(encoding))
+        else:
+            return self.__class__(self.data.encode())
+    def endswith(self, suffix, start=0, end=sys.maxint):
+        return self.data.endswith(suffix, start, end)
+    def expandtabs(self, tabsize=8):
+        return self.__class__(self.data.expandtabs(tabsize))
+    def find(self, sub, start=0, end=sys.maxint):
+        return self.data.find(sub, start, end)
+    def index(self, sub, start=0, end=sys.maxint):
+        return self.data.index(sub, start, end)
+    def isalpha(self): return self.data.isalpha()
+    def isalnum(self): return self.data.isalnum()
+    def isdecimal(self): return self.data.isdecimal()
+    def isdigit(self): return self.data.isdigit()
+    def islower(self): return self.data.islower()
+    def isnumeric(self): return self.data.isnumeric()
+    def isspace(self): return self.data.isspace()
+    def istitle(self): return self.data.istitle()
+    def isupper(self): return self.data.isupper()
+    def join(self, seq): return self.data.join(seq)
+    def ljust(self, width, *args):
+        return self.__class__(self.data.ljust(width, *args))
+    def lower(self): return self.__class__(self.data.lower())
+    def lstrip(self, chars=None): return self.__class__(self.data.lstrip(chars))
+    def partition(self, sep):
+        return self.data.partition(sep)
+    def replace(self, old, new, maxsplit=-1):
+        return self.__class__(self.data.replace(old, new, maxsplit))
+    def rfind(self, sub, start=0, end=sys.maxint):
+        return self.data.rfind(sub, start, end)
+    def rindex(self, sub, start=0, end=sys.maxint):
+        return self.data.rindex(sub, start, end)
+    def rjust(self, width, *args):
+        return self.__class__(self.data.rjust(width, *args))
+    def rpartition(self, sep):
+        return self.data.rpartition(sep)
+    def rstrip(self, chars=None): return self.__class__(self.data.rstrip(chars))
+    def split(self, sep=None, maxsplit=-1):
+        return self.data.split(sep, maxsplit)
+    def rsplit(self, sep=None, maxsplit=-1):
+        return self.data.rsplit(sep, maxsplit)
+    def splitlines(self, keepends=0): return self.data.splitlines(keepends)
+    def startswith(self, prefix, start=0, end=sys.maxint):
+        return self.data.startswith(prefix, start, end)
+    def strip(self, chars=None): return self.__class__(self.data.strip(chars))
+    def swapcase(self): return self.__class__(self.data.swapcase())
+    def title(self): return self.__class__(self.data.title())
+    def translate(self, *args):
+        return self.__class__(self.data.translate(*args))
+    def upper(self): return self.__class__(self.data.upper())
+    def zfill(self, width): return self.__class__(self.data.zfill(width))
+
+class MutableString(UserString):
+    """mutable string objects
+
+    Python strings are immutable objects.  This has the advantage, that
+    strings may be used as dictionary keys.  If this property isn't needed
+    and you insist on changing string values in place instead, you may cheat
+    and use MutableString.
+
+    But the purpose of this class is an educational one: to prevent
+    people from inventing their own mutable string class derived
+    from UserString and than forget thereby to remove (override) the
+    __hash__ method inherited from UserString.  This would lead to
+    errors that would be very hard to track down.
+
+    A faster and better solution is to rewrite your program using lists."""
+    def __init__(self, string=""):
+        self.data = string
+    def __hash__(self):
+        raise TypeError("unhashable type (it is mutable)")
+    def __setitem__(self, index, sub):
+        if index < 0:
+            index += len(self.data)
+        if index < 0 or index >= len(self.data): raise IndexError
+        self.data = self.data[:index] + sub + self.data[index+1:]
+    def __delitem__(self, index):
+        if index < 0:
+            index += len(self.data)
+        if index < 0 or index >= len(self.data): raise IndexError
+        self.data = self.data[:index] + self.data[index+1:]
+    def __setslice__(self, start, end, sub):
+        start = max(start, 0); end = max(end, 0)
+        if isinstance(sub, UserString):
+            self.data = self.data[:start]+sub.data+self.data[end:]
+        elif isinstance(sub, basestring):
+            self.data = self.data[:start]+sub+self.data[end:]
+        else:
+            self.data =  self.data[:start]+str(sub)+self.data[end:]
+    def __delslice__(self, start, end):
+        start = max(start, 0); end = max(end, 0)
+        self.data = self.data[:start] + self.data[end:]
+    def immutable(self):
+        return UserString(self.data)
+    def __iadd__(self, other):
+        if isinstance(other, UserString):
+            self.data += other.data
+        elif isinstance(other, basestring):
+            self.data += other
+        else:
+            self.data += str(other)
+        return self
+    def __imul__(self, n):
+        self.data *= n
+        return self
+
+class String(MutableString, Union):
+
+    _fields_ = [('raw', POINTER(c_char)),
+                ('data', c_char_p)]
+
+    def __init__(self, obj=""):
+        if isinstance(obj, (str, unicode, UserString)):
+            self.data = str(obj)
+        else:
+            self.raw = obj
+
+    def __len__(self):
+        return self.data and len(self.data) or 0
+
+    def from_param(cls, obj):
+        # Convert None or 0
+        if obj is None or obj == 0:
+            return cls(POINTER(c_char)())
+
+        # Convert from String
+        elif isinstance(obj, String):
+            return obj
+
+        # Convert from str
+        elif isinstance(obj, str):
+            return cls(obj)
+
+        # Convert from c_char_p
+        elif isinstance(obj, c_char_p):
+            return obj
+
+        # Convert from POINTER(c_char)
+        elif isinstance(obj, POINTER(c_char)):
+            return obj
+
+        # Convert from raw pointer
+        elif isinstance(obj, int):
+            return cls(cast(obj, POINTER(c_char)))
+
+        # Convert from object
+        else:
+            return String.from_param(obj._as_parameter_)
+    from_param = classmethod(from_param)
+
+def ReturnString(obj, func=None, arguments=None):
+    return String.from_param(obj)
+
+# As of ctypes 1.0, ctypes does not support custom error-checking
+# functions on callbacks, nor does it support custom datatypes on
+# callbacks, so we must ensure that all callbacks return
+# primitive datatypes.
+
+# Non-primitive return values wrapped with UNCHECKED won't be
+# typechecked, and will be converted to c_void_p.
+def UNCHECKED(type):
+    if (hasattr(type, "_type_") and isinstance(type._type_, str)
+        and type._type_ != "P"):
+        return type
+    else:
+        return c_void_p
+
+# ctypes doesn't have direct support for variadic functions, so we have to write
+# our own wrapper class
+class _variadic_function(object):
+    def __init__(self,func,restype,argtypes):
+        self.func=func
+        self.func.restype=restype
+        self.argtypes=argtypes
+    def _as_parameter_(self):
+        # So we can pass this variadic function as a function pointer
+        return self.func
+    def __call__(self,*args):
+        fixed_args=[]
+        i=0
+        for argtype in self.argtypes:
+            # Typecheck what we can
+            fixed_args.append(argtype.from_param(args[i]))
+            i+=1
+        return self.func(*fixed_args+list(args[i:]))
+
+# End preamble
+
+_libs = {}
+_libdirs = []
+
+# Begin loader
+
+# ----------------------------------------------------------------------------
+# Copyright (c) 2008 David James
+# Copyright (c) 2006-2008 Alex Holkner
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+
+ # * Redistributions of source code must retain the above copyright
+   # notice, this list of conditions and the following disclaimer.
+ # * Redistributions in binary form must reproduce the above copyright
+   # notice, this list of conditions and the following disclaimer in
+   # the documentation and/or other materials provided with the
+   # distribution.
+ # * Neither the name of pyglet nor the names of its
+   # contributors may be used to endorse or promote products
+   # derived from this software without specific prior written
+   # permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# ----------------------------------------------------------------------------
+
+import os.path, re, sys, glob
+import ctypes
+import ctypes.util
+
+def _environ_path(name):
+    if name in os.environ:
+        return os.environ[name].split(":")
+    else:
+        return []
+
+class LibraryLoader(object):
+    def __init__(self):
+        self.other_dirs=[]
+
+    def load_library(self,libname):
+        """Given the name of a library, load it."""
+        paths = self.getpaths(libname)
+
+        for path in paths:
+            if os.path.exists(path):
+                return self.load(path)
+
+        raise ImportError("%s not found." % libname)
+
+    def load(self,path):
+        """Given a path to a library, load it."""
+        try:
+            # Darwin requires dlopen to be called with mode RTLD_GLOBAL instead
+            # of the default RTLD_LOCAL.  Without this, you end up with
+            # libraries not being loadable, resulting in "Symbol not found"
+            # errors
+            if sys.platform == 'darwin':
+                return ctypes.CDLL(path, ctypes.RTLD_GLOBAL)
+            else:
+                return ctypes.cdll.LoadLibrary(path)
+        except OSError,e:
+            raise ImportError(e)
+
+    def getpaths(self,libname):
+        """Return a list of paths where the library might be found."""
+        if os.path.isabs(libname):
+            yield libname
+        else:
+            # FIXME / TODO return '.' and os.path.dirname(__file__)
+            for path in self.getplatformpaths(libname):
+                yield path
+
+            path = ctypes.util.find_library(libname)
+            if path: yield path
+
+    def getplatformpaths(self, libname):
+        return []
+
+# Darwin (Mac OS X)
+
+class DarwinLibraryLoader(LibraryLoader):
+    name_formats = ["lib%s.dylib", "lib%s.so", "lib%s.bundle", "%s.dylib",
+                "%s.so", "%s.bundle", "%s"]
+
+    def getplatformpaths(self,libname):
+        if os.path.pathsep in libname:
+            names = [libname]
+        else:
+            names = [format % libname for format in self.name_formats]
+
+        for dir in self.getdirs(libname):
+            for name in names:
+                yield os.path.join(dir,name)
+
+    def getdirs(self,libname):
+        '''Implements the dylib search as specified in Apple documentation:
+
+        http://developer.apple.com/documentation/DeveloperTools/Conceptual/
+            DynamicLibraries/Articles/DynamicLibraryUsageGuidelines.html
+
+        Before commencing the standard search, the method first checks
+        the bundle's ``Frameworks`` directory if the application is running
+        within a bundle (OS X .app).
+        '''
+
+        dyld_fallback_library_path = _environ_path("DYLD_FALLBACK_LIBRARY_PATH")
+        if not dyld_fallback_library_path:
+            dyld_fallback_library_path = [os.path.expanduser('~/lib'),
+                                          '/usr/local/lib', '/usr/lib']
+
+        dirs = []
+
+        if '/' in libname:
+            dirs.extend(_environ_path("DYLD_LIBRARY_PATH"))
+        else:
+            dirs.extend(_environ_path("LD_LIBRARY_PATH"))
+            dirs.extend(_environ_path("DYLD_LIBRARY_PATH"))
+
+        dirs.extend(self.other_dirs)
+        dirs.append(".")
+        dirs.append(os.path.dirname(__file__))
+
+        if hasattr(sys, 'frozen') and sys.frozen == 'macosx_app':
+            dirs.append(os.path.join(
+                os.environ['RESOURCEPATH'],
+                '..',
+                'Frameworks'))
+
+        dirs.extend(dyld_fallback_library_path)
+
+        return dirs
+
+# Posix
+
+class PosixLibraryLoader(LibraryLoader):
+    _ld_so_cache = None
+
+    def _create_ld_so_cache(self):
+        # Recreate search path followed by ld.so.  This is going to be
+        # slow to build, and incorrect (ld.so uses ld.so.cache, which may
+        # not be up-to-date).  Used only as fallback for distros without
+        # /sbin/ldconfig.
+        
+        # We assume the DT_RPATH and DT_RUNPATH binary sections are omitted.
+
+        directories = []
+        for name in ("LD_LIBRARY_PATH",
+                     "SHLIB_PATH", # HPUX
+                     "LIBPATH", # OS/2, AIX
+                     "LIBRARY_PATH", # BE/OS
+                    ):
+            if name in os.environ:
+                directories.extend(os.environ[name].split(os.pathsep))
+        directories.extend(self.other_dirs)
+        directories.append(".")
+        directories.append(os.path.dirname(__file__))
+
+        try: directories.extend([dir.strip() for dir in open('/etc/ld.so.conf')])
+        except IOError: pass
+
+        directories.extend(['/lib', '/usr/lib', '/lib64', '/usr/lib64'])
+
+        cache = {}
+        lib_re = re.compile(r'lib(.*)\.s[ol]')
+        ext_re = re.compile(r'\.s[ol]$')
+        for dir in directories:
+            try:
+                for path in glob.glob("%s/*.s[ol]*" % dir):
+                    file = os.path.basename(path)
+
+                    # Index by filename
+                    if file not in cache:
+                        cache[file] = path
+
+                    # Index by library name
+                    match = lib_re.match(file)
+                    if match:
+                        library = match.group(1)
+                        if library not in cache:
+                            cache[library] = path
+            except OSError:
+                pass
+
+        self._ld_so_cache = cache
+
+    def getplatformpaths(self, libname):
+        if self._ld_so_cache is None:
+            self._create_ld_so_cache()
+
+        result = self._ld_so_cache.get(libname)
+        if result: yield result
+
+        path = ctypes.util.find_library(libname)
+        if path: yield os.path.join("/lib",path)
+
+# Windows
+
+class _WindowsLibrary(object):
+    def __init__(self, path):
+        self.cdll = ctypes.cdll.LoadLibrary(path)
+        self.windll = ctypes.windll.LoadLibrary(path)
+
+    def __getattr__(self, name):
+        try: return getattr(self.cdll,name)
+        except AttributeError:
+            try: return getattr(self.windll,name)
+            except AttributeError:
+                raise
+
+class WindowsLibraryLoader(LibraryLoader):
+    name_formats = ["%s.dll", "lib%s.dll", "%slib.dll"]
+
+    def load_library(self, libname):
+        try:
+            result = LibraryLoader.load_library(self, libname)
+        except ImportError:
+            result = None
+            if os.path.sep not in libname:
+                for name in self.name_formats:
+                    try:
+                        result = getattr(ctypes.cdll, name % libname)
+                        if result:
+                            break
+                    except WindowsError:
+                        result = None
+            if result is None:
+                try:
+                    result = getattr(ctypes.cdll, libname)
+                except WindowsError:
+                    result = None
+            if result is None:
+                raise ImportError("%s not found." % libname)
+        return result
+
+    def load(self, path):
+        return _WindowsLibrary(path)
+
+    def getplatformpaths(self, libname):
+        if os.path.sep not in libname:
+            for name in self.name_formats:
+                dll_in_current_dir = os.path.abspath(name % libname)
+                if os.path.exists(dll_in_current_dir):
+                    yield dll_in_current_dir
+                path = ctypes.util.find_library(name % libname)
+                if path:
+                    yield path
+
+# Platform switching
+
+# If your value of sys.platform does not appear in this dict, please contact
+# the Ctypesgen maintainers.
+
+loaderclass = {
+    "darwin":   DarwinLibraryLoader,
+    "cygwin":   WindowsLibraryLoader,
+    "win32":    WindowsLibraryLoader
+}
+
+loader = loaderclass.get(sys.platform, PosixLibraryLoader)()
+
+def add_library_search_dirs(other_dirs):
+    loader.other_dirs = other_dirs
+
+load_library = loader.load_library
+
+del loaderclass
+
+# End loader
+
+add_library_search_dirs([])
+
+# Begin libraries
+
+_libs["QuickLink2"] = load_library("QuickLink2")
+
+# 1 libraries
+# End libraries
+
+# No modules
+
+QLDeviceId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 316
+
+QLDeviceGroupId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 327
+
+QLDeviceOrGroupId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 341
+
+QLSettingsId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 353
+
+QLCalibrationId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 365
+
+QLTargetId = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 377
+
+enum_anon_1 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_OK = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_CALIBRATING = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_LEFT_DATA = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_RIGHT_DATA = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QL_CALIBRATION_STATUS_NO_DATA = 4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+QLCalibrationStatus = enum_anon_1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 402
+
+enum_anon_2 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_5 = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_9 = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QL_CALIBRATION_TYPE_16 = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+QLCalibrationType = enum_anon_2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 421
+
+enum_anon_3 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QL_DEVICE_BANDWIDTH_MODE_AUTO = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QL_DEVICE_BANDWIDTH_MODE_MANUAL = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+QLDeviceBandwidthMode = enum_anon_3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 439
+
+enum_anon_4 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_RIGHT = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT_OR_RIGHT = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QL_DEVICE_EYES_TO_USE_LEFT_AND_RIGHT = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+QLDeviceEyesToUse = enum_anon_4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 463
+
+enum_anon_5 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QL_DEVICE_GAIN_MODE_AUTO = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QL_DEVICE_GAIN_MODE_MANUAL = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+QLDeviceGainMode = enum_anon_5 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 480
+
+enum_anon_6 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_NONE = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_FRAMES = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_MEDIAN_TIME = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_FRAMES = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_HEURISTIC_TIME = 4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QL_DEVICE_GAZE_POINT_FILTER_WEIGHTED_PREVIOUS_FRAME = 5 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+QLDeviceGazePointFilterMode = enum_anon_6 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 537
+
+enum_anon_7 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QL_DEVICE_IR_LIGHT_MODE_OFF = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QL_DEVICE_IR_LIGHT_MODE_AUTO = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+QLDeviceIRLightMode = enum_anon_7 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 554
+
+enum_anon_8 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_UNAVAILABLE = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_STOPPED = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_INITIALIZED = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QL_DEVICE_STATUS_STARTED = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+QLDeviceStatus = enum_anon_8 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 576
+
+enum_anon_9 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_OK = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DEVICE_ID = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_SETTINGS_ID = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_CALIBRATION_ID = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_TARGET_ID = 4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_PASSWORD = 5 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_PATH = 6 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DURATION = 7 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_POINTER = 8 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_TIMEOUT_ELAPSED = 9 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INTERNAL_ERROR = 10 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_BUFFER_TOO_SMALL = 11 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_CALIBRAION_NOT_INITIALIZED = 12 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_DEVICE_NOT_STARTED = 13 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_NOT_SUPPORTED = 14 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_NOT_FOUND = 15 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_UNAUTHORIZED_APPLICATION_RUNNING = 16 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QL_ERROR_INVALID_DEVICE_GROUP_ID = 17 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+QLError = enum_anon_9 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 640
+
+enum_anon_10 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QL_EYE_TYPE_LEFT = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QL_EYE_TYPE_RIGHT = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+QLEyeType = enum_anon_10 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 657
+
+enum_anon_11 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_OFF = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_ON = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_LEFT_EYE_STATUS = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_RIGHT_EYE_STATUS = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_LEFT_EYE_STATUS_FILTERED = 4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QL_INDICATOR_MODE_RIGHT_EYE_STATUS_FILTERED = 5 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+QLIndicatorMode = enum_anon_11 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 688
+
+enum_anon_12 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QL_INDICATOR_TYPE_LEFT = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QL_INDICATOR_TYPE_RIGHT = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+QLIndicatorType = enum_anon_12 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 705
+
+enum_anon_13 = c_int # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT = 0 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT8 = 1 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT16 = 2 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT32 = 3 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_INT64 = 4 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT = 5 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT8 = 6 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT16 = 7 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT32 = 8 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_UINT64 = 9 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_FLOAT = 10 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_DOUBLE = 11 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_BOOL = 12 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_STRING = 13 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QL_SETTING_TYPE_VOID_POINTER = 14 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+QLSettingType = enum_anon_13 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 761
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 788
+class struct_anon_14(Structure):
+    pass
+
+struct_anon_14.__slots__ = [
+    'targetId',
+    'x',
+    'y',
+]
+struct_anon_14._fields_ = [
+    ('targetId', QLTargetId),
+    ('x', c_float),
+    ('y', c_float),
+]
+
+QLCalibrationTarget = struct_anon_14 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 788
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 812
+class struct_anon_15(Structure):
+    pass
+
+struct_anon_15.__slots__ = [
+    'x',
+    'y',
+    'score',
+]
+struct_anon_15._fields_ = [
+    ('x', c_float),
+    ('y', c_float),
+    ('score', c_float),
+]
+
+QLCalibrationScore = struct_anon_15 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 812
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 834
+class struct_anon_16(Structure):
+    pass
+
+struct_anon_16.__slots__ = [
+    'sensorWidth',
+    'sensorHeight',
+    'serialNumber',
+    'modelName',
+]
+struct_anon_16._fields_ = [
+    ('sensorWidth', c_int),
+    ('sensorHeight', c_int),
+    ('serialNumber', c_char * 128),
+    ('modelName', c_char * 128),
+]
+
+QLDeviceInfo = struct_anon_16 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 834
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 845
+class struct_anon_17(Structure):
+    pass
+
+struct_anon_17.__slots__ = [
+    'x',
+    'y',
+]
+struct_anon_17._fields_ = [
+    ('x', c_double),
+    ('y', c_double),
+]
+
+QLXYPairDouble = struct_anon_17 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 845
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 856
+class struct_anon_18(Structure):
+    pass
+
+struct_anon_18.__slots__ = [
+    'x',
+    'y',
+]
+struct_anon_18._fields_ = [
+    ('x', c_float),
+    ('y', c_float),
+]
+
+QLXYPairFloat = struct_anon_18 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 856
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 876
+class struct_anon_19(Structure):
+    pass
+
+struct_anon_19.__slots__ = [
+    'x',
+    'y',
+    'width',
+    'height',
+]
+struct_anon_19._fields_ = [
+    ('x', c_int),
+    ('y', c_int),
+    ('width', c_int),
+    ('height', c_int),
+]
+
+QLRectInt = struct_anon_19 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 876
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 920
+class struct_anon_20(Structure):
+    pass
+
+struct_anon_20.__slots__ = [
+    'PixelData',
+    'Width',
+    'Height',
+    'Timestamp',
+    'Gain',
+    'FrameNumber',
+    'ROI',
+    'Reserved',
+]
+struct_anon_20._fields_ = [
+    ('PixelData', POINTER(c_ubyte)),
+    ('Width', c_int),
+    ('Height', c_int),
+    ('Timestamp', c_double),
+    ('Gain', c_int),
+    ('FrameNumber', c_long),
+    ('ROI', QLRectInt),
+    ('Reserved', POINTER(None) * 12),
+]
+
+QLImageData = struct_anon_20 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 920
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 959
+class struct_anon_21(Structure):
+    pass
+
+struct_anon_21.__slots__ = [
+    'Found',
+    'Calibrated',
+    'PupilDiameter',
+    'Pupil',
+    'Glint0',
+    'Glint1',
+    'GazePoint',
+    'Reserved',
+]
+struct_anon_21._fields_ = [
+    ('Found', c_long),
+    ('Calibrated', c_long),
+    ('PupilDiameter', c_float),
+    ('Pupil', QLXYPairFloat),
+    ('Glint0', QLXYPairFloat),
+    ('Glint1', QLXYPairFloat),
+    ('GazePoint', QLXYPairFloat),
+    ('Reserved', POINTER(None) * 16),
+]
+
+QLEyeData = struct_anon_21 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 959
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 988
+class struct_anon_22(Structure):
+    pass
+
+struct_anon_22.__slots__ = [
+    'Valid',
+    'x',
+    'y',
+    'LeftWeight',
+    'RightWeight',
+    'Reserved',
+]
+struct_anon_22._fields_ = [
+    ('Valid', c_long),
+    ('x', c_float),
+    ('y', c_float),
+    ('LeftWeight', c_float),
+    ('RightWeight', c_float),
+    ('Reserved', POINTER(None) * 16),
+]
+
+QLWeightedGazePoint = struct_anon_22 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 988
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 1033
+class struct_anon_23(Structure):
+    pass
+
+struct_anon_23.__slots__ = [
+    'ImageData',
+    'LeftEye',
+    'RightEye',
+    'WeightedGazePoint',
+    'Focus',
+    'Distance',
+    'Bandwidth',
+    'DeviceId',
+    'Reserved',
+]
+struct_anon_23._fields_ = [
+    ('ImageData', QLImageData),
+    ('LeftEye', QLEyeData),
+    ('RightEye', QLEyeData),
+    ('WeightedGazePoint', QLWeightedGazePoint),
+    ('Focus', c_float),
+    ('Distance', c_float),
+    ('Bandwidth', c_int),
+    ('DeviceId', QLDeviceId),
+    ('Reserved', POINTER(None) * 14),
+]
+
+QLFrameData = struct_anon_23 # ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 1033
+
+__const = c_int # <command-line>: 5
+
+# <command-line>: 8
+try:
+    CTYPESGEN = 1
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 19
+try:
+    STRING_LENGTH_128 = 128
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 58
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_MODE = 'DeviceBandwidthMode'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 69
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_PERCENT_FULL = 'DeviceBandwidthPercentFull'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 80
+try:
+    QL_SETTING_DEVICE_BANDWIDTH_PERCENT_TRACKING = 'DeviceBandwidthPercentTracking'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 92
+try:
+    QL_SETTING_DEVICE_BINNING = 'DeviceBinning'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 102
+try:
+    QL_SETTING_DEVICE_CALIBRATE_ENABLED = 'DeviceCalibrateEnabled'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 109
+try:
+    QL_SETTING_DEVICE_DISTANCE = 'DeviceDistance'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 116
+try:
+    QL_SETTING_DEVICE_EXPOSURE = 'DeviceExposure'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 127
+try:
+    QL_SETTING_DEVICE_FLIP_X = 'DeviceFlipX'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 138
+try:
+    QL_SETTING_DEVICE_FLIP_Y = 'DeviceFlipY'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 148
+try:
+    QL_SETTING_DEVICE_GAIN_MODE = 'DeviceGainMode'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 159
+try:
+    QL_SETTING_DEVICE_GAIN_VALUE = 'DeviceGainValue'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 169
+try:
+    QL_SETTING_DEVICE_GAZE_POINT_FILTER_MODE = 'DeviceGazePointFilterMode'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 179
+try:
+    QL_SETTING_DEVICE_GAZE_POINT_FILTER_VALUE = 'DeviceGazePointFilterValue'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 189
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_ENABLED = 'DeviceImageProcessingEnabled'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 198
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYES_TO_FIND = 'DeviceImageProcessingEyesToUse'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 211
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_LEFT = 'DeviceImageProcessingEyeRadiusLeft'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 224
+try:
+    QL_SETTING_DEVICE_IMAGE_PROCESSING_EYE_RADIUS_RIGHT = 'DeviceImageProcessingEyeRadiusRight'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 234
+try:
+    QL_SETTING_DEVICE_INTERPOLATE_ENABLED = 'DeviceInterpolateEnabled'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 242
+try:
+    QL_SETTING_DEVICE_IR_LIGHT_MODE = 'DeviceIRLightMode'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 249
+try:
+    QL_SETTING_DEVICE_LENS_FOCAL_LENGTH = 'DeviceLensFocalLength'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 260
+try:
+    QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_X = 'DeviceRoiMoveThresholdPercentX'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 271
+try:
+    QL_SETTING_DEVICE_ROI_MOVE_THRESHOLD_PERCENT_Y = 'DeviceRoiMoveThresholdPercentY'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 281
+try:
+    QL_SETTING_DEVICE_ROI_SIZE_PERCENT_X = 'DeviceRoiSizePercentX'
+except:
+    pass
+
+# ioHub\\devices\\eyeTrackerInterface\\HW\\EyeTech\\QuickLink\\reference\\QLTypes.h: 291
+try:
+    QL_SETTING_DEVICE_ROI_SIZE_PERCENT_Y = 'DeviceRoiSizePercentY'
+except:
+    pass
+
+# No inserted files
+


### PR DESCRIPTION
I ran the header files for QL2 through ctypesgen.

http://code.google.com/p/ctypesgen/

And it parsed out a lot of information and converted partially it to a ctypes style wrapper.

ctypesgen can't handle bool yet, so I changed the 3 bools to longs temporarily ('Valid', 'Calibrated', and 'Found' fields).  And then in the generated file, I changed them to c_bool

There is something that it doesn't like about the syntax for the function prototypes throughout QuickLink2.h. "Line 20: ... Syntax Error: '(' "

The raw output from ctypesgen is sitting in:
ioHub/devices/eyeTrackerInterface/HW/EyeTech/QuickLink/reference/pyQuickLink2.py

I copied a bunch of the generated stuff out (lines 598 to the end) and put it in qltypes.py .

For the enums and the other structs it used an odd temporary naming logic.  It called them _anon_###, and set _anon_### to a c_int if it was an enum.

It also setup **slots** for accessing the different fields.  I don't exactly understand their usage yet, but here is a message someone posted about them: 
http://osdir.com/ml/python.ctypes/2003-02/msg00035.html
